### PR TITLE
Fix attrs loop in yXmlText

### DIFF
--- a/src/types/YXmlText.js
+++ b/src/types/YXmlText.js
@@ -56,7 +56,7 @@ export class YXmlText extends YText {
         const node = nestedNodes[i]
         str += `<${node.nodeName}`
         for (let j = 0; j < node.attrs.length; j++) {
-          const attr = node.attrs[i]
+          const attr = node.attrs[j]
           str += ` ${attr.key}="${attr.value}"`
         }
         str += '>'


### PR DESCRIPTION
The element attribute loop use the index of the nodes array. Updated to use the index of the attributes array. The problem is that by the first node the code will only apply the first attribute and for the second node only the second attribute. In the other yXml types are fine.