### PR TITLE
fix setting Doc.gc value in Doc's constructor

### DIFF
--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -27,7 +27,7 @@ export class Doc extends Observable {
    */
   constructor (conf = {}) {
     super()
-    this.gc = conf.gc || true
+    this.gc = typeof conf.gc !== 'undefined' ? conf.gc : true
     this.clientID = random.uint32()
     /**
      * @type {Map<string, AbstractType<YEvent>>}


### PR DESCRIPTION
now it is impossible to disable gc in a document, because Doc's constructor always sets gc to true regardless of config