### PR TITLE
basic Y.Text toJSON returns {unformatted:string}

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -669,6 +669,17 @@ export class YText extends AbstractType {
   }
 
   /**
+   * Returns the unformatted string representation of this YText type.
+   *
+   * Avoids undefined being returned when called as a nested type.
+   *
+   * @public
+   */
+  toJSON () {
+    return this.toString()
+  }
+
+  /**
    * Apply a {@link Delta} on this shared YText type.
    *
    * @param {any} delta The changes to apply on this element.

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -149,3 +149,12 @@ export const testSnapshotDeleteAfter = tc => {
   const state1 = text0.toDelta(snapshot1)
   t.compare(state1, [{ insert: 'abcd' }])
 }
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testToJson = tc => {
+  const {text0 } = init(tc, { users: 1 })
+  text0.insert(0, 'abc', { bold: true })
+  t.assert(text0.toJSON() === 'abc', 'toJSON returns the unformatted text')
+}


### PR DESCRIPTION
This avoids text nodes in nested structures returning undefined when toJSON is called by a parent.