### PR TITLE
Fix missing closing bracket in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ necessary.
     <b><code>insert(index:number, content:Array&lt;object|boolean|Array|string|number|Uint8Array|Y.Type&gt;)</code></b>
     <dd>
 Insert content at <var>index</var>. Note that content is an array of elements.
-I.e. <code>array.insert(0, [1]</code> splices the list and inserts 1 at
+I.e. <code>array.insert(0, [1])</code> splices the list and inserts 1 at
 position 0.
     </dd>
     <b><code>push(Array&lt;Object|boolean|Array|string|number|Uint8Array|Y.Type&gt;)</code></b>


### PR DESCRIPTION
Fix missing closing brackets in line 
`array.insert(0, [1]`
under the Y-Array documentation.