### PR TITLE
Enhance Y.Array insertions to behave like normal arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ position 0.
     </dd>
     <b><code>push(Array&lt;Object|boolean|Array|string|number|Uint8Array|Y.Type&gt;)</code></b>
     <dd></dd>
+    <b><code>unshift(Array&lt;Object|boolean|Array|string|number|Uint8Array|Y.Type&gt;)</code></b>
+    <dd></dd>
     <b><code>delete(index:number, length:number)</code></b>
     <dd></dd>
     <b><code>get(index:number)</code></b>

--- a/src/types/YArray.js
+++ b/src/types/YArray.js
@@ -101,6 +101,7 @@ export class YArray extends AbstractType {
    *
    * @param {number} index The index to insert content at.
    * @param {Array<T>} content The array of content
+   * @return {number} The upated YArray length
    */
   insert (index, content) {
     if (this.doc !== null) {
@@ -110,24 +111,27 @@ export class YArray extends AbstractType {
     } else {
       /** @type {Array<any>} */ (this._prelimContent).splice(index, 0, ...content)
     }
+    return this.length
   }
 
   /**
    * Appends content to this YArray.
    *
    * @param {Array<T>} content Array of content to append.
+   * @return {number} The upated YArray length
    */
   push (content) {
-    this.insert(this.length, content)
+    return this.insert(this.length, content)
   }
 
   /**
    * Preppends content to this YArray.
    *
    * @param {Array<T>} content Array of content to preppend.
+   * @return {number} The upated YArray length
    */
   unshift (content) {
-    this.insert(0, content)
+    return this.insert(0, content)
   }
 
   /**

--- a/src/types/YArray.js
+++ b/src/types/YArray.js
@@ -122,6 +122,15 @@ export class YArray extends AbstractType {
   }
 
   /**
+   * Preppends content to this YArray.
+   *
+   * @param {Array<T>} content Array of content to preppend.
+   */
+  unshift (content) {
+    this.insert(0, content)
+  }
+
+  /**
    * Deletes elements starting from an index.
    *
    * @param {number} index Index at which to start deleting elements


### PR DESCRIPTION
Good day @dmonad.

I have tried to make Y.Array functions behave a bit more like normal arrays do in JavaScript.
Here are the changes I have made:
- Add unshift(Array<T>) operation which preppends the content to the Y.Array.
- insert, push, and unshift now return the length of the updated content.

I hope these changes would be helpful, as people can expect Y.Array behave a bit more like normal arrays.

I also have a question:
I was thinking of implementing pop() and shift(). However, considering that push and unshift take an array as an argument, will it not create inconsistency if pop() and shift() only delete and return the last element? I was thinking of taking an argument of length (ex. pop(3) to delete and return the 3 topmost elements of the Y.Array). What do you think?

Regards,
Mansehej.