### PR TITLE
feat: Add getUsers method to get all users associated with a doc

### DIFF
--- a/src/utils/PermanentUserData.js
+++ b/src/utils/PermanentUserData.js
@@ -139,4 +139,21 @@ export class PermanentUserData {
     }
     return null
   }
+
+  /**
+   * @return {Array<string>}
+   */
+  getUsers () {
+    const users = new Map()
+
+    for (const [userDescription] of this.dss.entries()) {
+      users.set(userDescription, true)
+    }
+
+    for (const client of this.clients.entries()) {
+      users.set(client[1], true)
+    }
+
+    return Array.from(users.keys())
+  }
 }

--- a/tests/encoding.tests.js
+++ b/tests/encoding.tests.js
@@ -60,4 +60,8 @@ export const testPermanentUserData = async tc => {
   applyUpdate(ydoc3, encodeStateAsUpdate(ydoc1))
   const pd3 = new PermanentUserData(ydoc3)
   pd3.setUserMapping(ydoc3, ydoc3.clientID, 'user a')
+
+  t.assert(pd3.getUsers().length === 2)
+  t.assert(pd3.getUsers().includes('user a'))
+  t.assert(pd3.getUsers().includes('user b'))
 }


### PR DESCRIPTION
It's a common usecase to know which users have touched a doc, if using `PermanentUserData` this adds a handy accessor for the information.

I know you're interested in refactoring `PermanentUserData` to a different storage method – the more clear interfaces we can provide now the easier it will make refactoring the internals in the future.