### PR TITLE
fix crash when the walker didn't match because n will be null

### DIFF
--- a/src/types/YXmlFragment.js
+++ b/src/types/YXmlFragment.js
@@ -83,7 +83,7 @@ export class YXmlTreeWalker {
      * @type {Item|null}
      */
     let n = this._currentNode
-    let type = /** @type {any} */ (n.content).type
+    let type = /** @type {any} */ n && n.content && (n.content).type
     if (n !== null && (!this._firstCall || n.deleted || !this._filter(type))) { // if first call, we check if we can use the first item
       do {
         type = /** @type {any} */ (n.content).type

--- a/src/types/YXmlFragment.js
+++ b/src/types/YXmlFragment.js
@@ -83,7 +83,7 @@ export class YXmlTreeWalker {
      * @type {Item|null}
      */
     let n = this._currentNode
-    let type = /** @type {any} */ n && n.content && (n.content).type
+    let type = n && n.content && /** @type {any} */ (n.content).type
     if (n !== null && (!this._firstCall || n.deleted || !this._filter(type))) { // if first call, we check if we can use the first item
       do {
         type = /** @type {any} */ (n.content).type


### PR DESCRIPTION
When you use a tree walker and it doesn't match any nodes, it will crash. This prevents the crash since null was being check but not for the type before iterating the loop.