### PR TITLE
Expose abstracttype created event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export {
   ContentAny,
   ContentString,
   ContentType,
+  typeRefs,
   AbstractType,
   RelativePosition,
   getTypeChildren,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-
 export {
   Doc,
   Transaction,
+  observeTypeCreated,
   YArray as Array,
   YMap as Map,
   YText as Text,
@@ -25,7 +25,6 @@ export {
   ContentAny,
   ContentString,
   ContentType,
-  typeRefs,
   AbstractType,
   RelativePosition,
   getTypeChildren,
@@ -82,5 +81,5 @@ export {
   encodeRelativePosition,
   decodeRelativePosition,
   diffUpdate,
-  diffUpdateV2
-} from './internals.js'
+  diffUpdateV2,
+} from "./internals.js";

--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -249,6 +249,21 @@ export const callTypeObservers = (type, transaction, event) => {
 }
 
 /**
+ * Event handlers
+ * @type {EventHandler<AbstractType<any>, undefined>}
+ */
+const typeCreatedEventHandler = createEventHandler();
+
+/**
+ * Observe all events that are created on this type.
+ *
+ * @param {function(AbstractType<any>, undefined):void} f Observer function
+ */
+export function observeTypeCreated (f) {
+  addEventHandlerListener(typeCreatedEventHandler, f)
+}
+
+/**
  * @template EventType
  * Abstract Yjs Type class
  */
@@ -285,6 +300,8 @@ export class AbstractType {
      * @type {null | Array<ArraySearchMarker>}
      */
     this._searchMarker = null
+
+    callEventHandlerListeners(typeCreatedEventHandler, this, undefined);
   }
 
   /**

--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -249,13 +249,13 @@ export const callTypeObservers = (type, transaction, event) => {
 }
 
 /**
- * Event handlers
+ * Event handler for when new instances of AbstractType are instantiated
  * @type {EventHandler<AbstractType<any>, undefined>}
  */
 const typeCreatedEventHandler = createEventHandler();
 
 /**
- * Observe all events that are created on this type.
+ * Observe instantiation events of new AbstractTypes
  *
  * @param {function(AbstractType<any>, undefined):void} f Observer function
  */


### PR DESCRIPTION
@dmonad Would you be willing to expose this?

For developing libraries similar to MobY, it's necessary to learn about each Y.Map, Y.Array, etc. to be instantiated. Trying to hook into this purely from external code becomes extremely messy, because many of these types are instantiated internally in Yjs. I hope this can provide a clean solution, while we can still keep the other wrappers / patches in a different module