### PR TITLE
add `clear` to YMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ or any of its children.
     <dd></dd>
     <b><code>get(index:number)</code></b>
     <dd></dd>
+    <b><code>clear()</code></b>
+    <dd>Removes all elements from this YMap.</dd>
     <b><code>clone():Y.Map</code></b>
     <dd>Clone this type into a fresh Yjs type.</dd>
     <b><code>toJSON():Object&lt;string, Object|boolean|Array|string|number|Uint8Array&gt;</code></b>

--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -238,6 +238,22 @@ export class YMap extends AbstractType {
   }
 
   /**
+   * Removes all elements from this YMap.
+   */
+  clear () {
+    if (this.doc !== null) {
+      transact(this.doc, transaction => {
+        this.forEach(function (value, key, map) {
+          console.log('deleting', key)
+          typeMapDelete(transaction, map, key)
+        })
+      })
+    } else {
+      /** @type {Map<string, any>} */ (this._prelimContent).clear()
+    }
+  }
+
+  /**
    * @param {UpdateEncoderV1 | UpdateEncoderV2} encoder
    */
   _write (encoder) {


### PR DESCRIPTION
 Remove all elements from a YMap 

Uses `delete` via `forEach` to create an event history (is this the correct approach?)