### PR TITLE
Fix XmlElement.clone and XmlFragment.clone

### DIFF
--- a/src/types/YXmlElement.js
+++ b/src/types/YXmlElement.js
@@ -81,7 +81,7 @@ export class YXmlElement extends YXmlFragment {
       el.setAttribute(key, attrs[key])
     }
     // @ts-ignore
-    el.insert(0, el.toArray().map(item => item instanceof AbstractType ? item.clone() : item))
+    el.insert(0, this.toArray().map(item => item instanceof AbstractType ? item.clone() : item))
     return el
   }
 

--- a/src/types/YXmlFragment.js
+++ b/src/types/YXmlFragment.js
@@ -167,7 +167,7 @@ export class YXmlFragment extends AbstractType {
   clone () {
     const el = new YXmlFragment()
     // @ts-ignore
-    el.insert(0, el.toArray().map(item => item instanceof AbstractType ? item.clone() : item))
+    el.insert(0, this.toArray().map(item => item instanceof AbstractType ? item.clone() : item))
     return el
   }
 

--- a/tests/y-xml.tests.js
+++ b/tests/y-xml.tests.js
@@ -133,3 +133,21 @@ export const testInsertafter = tc => {
     el.insertAfter(deepsecond1, [new Y.XmlText()])
   })
 }
+
+
+/**
+ * @param {t.TestCase} tc
+ */
+ export const testClone = tc => {
+  const ydoc = new Y.Doc()
+  const yxml = ydoc.getXmlFragment()
+  const first = new Y.XmlText('text')
+  const second = new Y.XmlElement('p')
+  const third = new Y.XmlElement('p')
+  yxml.push([first, second, third])
+  t.compareArrays(yxml.toArray(), [first, second, third])
+
+  const cloneYxml = yxml.clone()
+  t.assert(cloneYxml.length === 3)
+  t.assert(cloneYxml.toJSON() === yxml.toJSON())
+}


### PR DESCRIPTION
I was attempting to clone a `Y.XmlFragment` and I noticed that the clone function didn't seem to work / look right. I can't figure out why the `.toJSON` for the original doesn't `===` the clone, so I need some help completing this PR.

What I'm really attempting to do is append some Prosemirror nodes to an existing `Y.XmlFragment`. The best idea I came up with was to create another Y.Doc from  via `prosemirrorToYDoc` in `y-prosemirror` and then clone/append the newly created `Y.XmlFragment` into the existing `Y.XmlFragment`. I haven't quite figured out how to get it all working yet, so any suggestions would be appreciated!