### PR TITLE
fix: attributes may not applied to texts

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -164,13 +164,13 @@ const insertNegatedAttributes = (transaction, parent, currPos, negatedAttributes
   }
   const doc = transaction.doc
   const ownClientId = doc.clientID
-  let nextFormat = currPos.left
-  const right = currPos.right
+  const left = currPos.left
+  let right = currPos.right
   negatedAttributes.forEach((val, key) => {
-    nextFormat = new Item(createID(ownClientId, getState(doc.store, ownClientId)), nextFormat, nextFormat && nextFormat.lastId, right, right && right.id, parent, null, new ContentFormat(key, val))
-    nextFormat.integrate(transaction, 0)
-    currPos.right = nextFormat
+    right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentFormat(key, val))
+    right.integrate(transaction, 0)
   })
+  currPos.right = right
 }
 
 /**


### PR DESCRIPTION
Resolves: #319

## The case:

```js
xmlText.applyDelta([
  { insert: "A", attributes: { em: {}, strong: {} } }
]);
```

## Before this PR:

### After insert attributes and A:
`type` is `<em> -> <strong> -> A`.
`currPos.left` is `<strong>`.
`currPos.right` is `A`.

### After insert negated attributes:
`type` is `<em> -> <strong> -> A -> </em> -> </strong>`, which should be `<em> -> <strong> -> A -> </strong> -> </em>`.
`currPos.left` is `A`.
`currPos.right` is `</strong>`, which is not a valid pos (`</em>` is be between `currPos.left` and `currPos.right`).

## After this PR:

### After insert attributes and A:
Same as before.

### After insert negated attributes:
`type` is `<em> -> <strong> -> A -> </strong> -> </em>`.
`currPos.left` is `A`.
`currPos.right` is `</strong>`.

Thus, the `currPos.currentAttributes` can be cleared correctly in `minimizeAttributeChanges()`, which resolves #319.