### PR TITLE
Fix type annotation of getMap

### DIFF
--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -194,8 +194,9 @@ export class Doc extends Observable {
   }
 
   /**
+   * @template T
    * @param {string} [name]
-   * @return {YMap<any>}
+   * @return {YMap<T>}
    *
    * @public
    */


### PR DESCRIPTION
Make `getMap<T>()` take a generic type parameter just like `getArray<T>()`.

<sub><a href="https://huly.app/guest/w-githubdmonad-yjs-660d5772-70f06a0a22-d28cf5?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBkNjRjOThjN2YzNTBiMTEyMTQ0Y2IiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.Awz24ugTwG5-bSb5vge3KoHVeU_-a-GQJ1gliPzzajU">Huly&reg;: <b>YJS-639</b></a></sub>