### PR TITLE
Void tags cannot have end tags or contents

### DIFF
--- a/src/types/YXmlElement.js
+++ b/src/types/YXmlElement.js
@@ -96,6 +96,7 @@ export class YXmlElement extends YXmlFragment {
    * @public
    */
   toString () {
+    const voidElements = ["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"]
     const attrs = this.getAttributes()
     const stringBuilder = []
     const keys = []
@@ -110,6 +111,9 @@ export class YXmlElement extends YXmlFragment {
     }
     const nodeName = this.nodeName.toLocaleLowerCase()
     const attrsString = stringBuilder.length > 0 ? ' ' + stringBuilder.join(' ') : ''
+    if(voidElements.includes(nodeName)) {
+      return `<${nodeName}${attrsString} />`
+    }
     return `<${nodeName}${attrsString}>${super.toString()}</${nodeName}>`
   }
 


### PR DESCRIPTION
Running `.toString` on the `YXmlElement` type will always output end tags (and potentially content) for void tags. This results in invalid HTML strings being generated. A few examples below:

```
console.log((new Y.XmlElement('br')).toString()) // '<br></br>'
console.log((new Y.XmlElement('img')).toString()) // '<img></img>'
```


This PR uses the the list of void tag tags found in the HTML 5 syntax spec (https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements) to output a self-closing tag for XMLElements whose `nodeName` occurs in the list of void elements.