### PR TITLE
Remove broken link to terminated cattaz website

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Sponsorship also comes with special perks! [![Become a Sponsor](https://img.shie
 * [JoeDocs](https://joedocs.com/) An open collaborative wiki.
 * [Pluxbox RadioManager](https://pluxbox.com/) A web-based app to
   collaboratively organize radio broadcasts.
-* [Cattaz](http://cattaz.io/) A wiki that can run custom applications in the
-  wiki pages.
 * [Alldone](https://alldone.app/) A next-gen project management and
   collaboration platform.
 


### PR DESCRIPTION
Someone else bought the domain and redirects it to a crummy google results reskin with ads.

According to the [FujitsuLaboratories/cattaz repo](https://github.com/FujitsuLaboratories/cattaz), the website has been terminated.