### PR TITLE
Undo event

### DIFF
--- a/src/structs/Item.js
+++ b/src/structs/Item.js
@@ -210,10 +210,21 @@ export const redoItem = (transaction, item, redoitems, itemsToDelete) => {
       }
       right = right.right
     }
+
+    /**
+     * @type {Item|null}
+     */
+    let leftTrace = left
     // Iterate right while right is in itemsToDelete
     // If it is intended to delete right while item is redone, we can expect that item should replace right.
-    while (left !== null && left.right !== null && left.right !== right && itemsToDelete.findIndex(d => d === /** @type {Item} */ (left).right) >= 0) {
-      left = left.right
+    while (leftTrace !== null && leftTrace.right !== null && leftTrace.right !== right) {
+      if (itemsToDelete.findIndex(d => d === /** @type {Item} */ leftTrace) >= 0) {
+        break
+      }
+      leftTrace = leftTrace.right
+    }
+    if (leftTrace !== null) {
+      left = leftTrace
     }
   }
   const nextClock = getState(store, ownClientID)

--- a/src/utils/UndoManager.js
+++ b/src/utils/UndoManager.js
@@ -186,6 +186,7 @@ export class UndoManager extends Observable {
         }
       })
       const now = time.getUnixTime()
+      let didAdd = false;
       if (now - this.lastChange < captureTimeout && stack.length > 0 && !undoing && !redoing) {
         // append change to last stack op
         const lastOp = stack[stack.length - 1]
@@ -193,6 +194,7 @@ export class UndoManager extends Observable {
         lastOp.insertions = mergeDeleteSets([lastOp.insertions, insertions])
       } else {
         // create a new stack op
+        didAdd = true;
         stack.push(new StackItem(transaction.deleteSet, insertions))
       }
       if (!undoing && !redoing) {
@@ -204,7 +206,9 @@ export class UndoManager extends Observable {
           keepItem(item, true)
         }
       })
-      this.emit('stack-item-added', [{ stackItem: stack[stack.length - 1], origin: transaction.origin, type: undoing ? 'redo' : 'undo', changedParentTypes: transaction.changedParentTypes }, this])
+      if (didAdd) {
+        this.emit('stack-item-added', [{ stackItem: stack[stack.length - 1], origin: transaction.origin, type: undoing ? 'redo' : 'undo', changedParentTypes: transaction.changedParentTypes }, this])
+      }
     })
   }
 

--- a/tests/undo-redo.tests.js
+++ b/tests/undo-redo.tests.js
@@ -358,6 +358,26 @@ export const testUndoNestedUndoIssue = tc => {
     text.set('blocks', blocks3block)
   })
 
+  const blocks4 = new Y.Array()
+  const blocks4block = new Y.Map()
+  doc.transact(() => {
+    blocks4block.set('text', 'Something Else 2')
+    blocks4.push([blocks4block])
+    text.set('blocks', blocks4block)
+  })
+
+  const blocks5 = new Y.Array()
+  const blocks5block = new Y.Map()
+  doc.transact(() => {
+    blocks5block.set('text', 'Something Else 3')
+    blocks5.push([blocks5block])
+    text.set('blocks', blocks5block)
+  })
+
+  t.compare(design.toJSON(), { text: { blocks: { text: 'Something Else 3' } } })
+  undoManager.undo()
+  t.compare(design.toJSON(), { text: { blocks: { text: 'Something Else 2' } } })
+  undoManager.undo()
   t.compare(design.toJSON(), { text: { blocks: { text: 'Something Else' } } })
   undoManager.undo()
   t.compare(design.toJSON(), { text: { blocks: { text: 'Something' } } })
@@ -371,4 +391,8 @@ export const testUndoNestedUndoIssue = tc => {
   t.compare(design.toJSON(), { text: { blocks: { text: 'Something' } } })
   undoManager.redo()
   t.compare(design.toJSON(), { text: { blocks: { text: 'Something Else' } } })
+  undoManager.redo()
+  t.compare(design.toJSON(), { text: { blocks: { text: 'Something Else 2' } } })
+  undoManager.redo()
+  t.compare(design.toJSON(), { text: { blocks: { text: 'Something Else 3' } } })
 }


### PR DESCRIPTION
Includes doodlewind/yjs#undo_patch

Only emit `stack-item-added` when an item is actually added, vs coalesced with a previous one if `captureTimeout is > 0`

Used to implement an undo manager that is comprised of several Y.UndoManagers. Since this changes the current behavior, unclear if it's worth merging in.