### PR TITLE
make size() public

### DIFF
--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -129,7 +129,7 @@ export class YMap extends AbstractType {
    *
    * @return {number}
    */
-  get size () {
+  size () {
     return [...createMapIterator(this._map)].length
   }
 


### PR DESCRIPTION
perhaps it was a typo? this should allow `size()` of map to be public.