### PR TITLE
Add more accurate typing for YEvent.target

### DIFF
--- a/src/structs/ContentType.js
+++ b/src/structs/ContentType.js
@@ -39,7 +39,7 @@ export const YXmlTextRefID = 6
  */
 export class ContentType {
   /**
-   * @param {AbstractType<YEvent>} type
+   * @param {AbstractType<any>} type
    */
   constructor (type) {
     /**

--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -278,7 +278,7 @@ export class AbstractType {
     this._eH = createEventHandler()
     /**
      * Deep event handlers
-     * @type {EventHandler<Array<YEvent>,Transaction>}
+     * @type {EventHandler<Array<YEvent<any>>,Transaction>}
      */
     this._dEH = createEventHandler()
     /**
@@ -364,7 +364,7 @@ export class AbstractType {
   /**
    * Observe all events that are created by this type and its children.
    *
-   * @param {function(Array<YEvent>,Transaction):void} f Observer function
+   * @param {function(Array<YEvent<any>>,Transaction):void} f Observer function
    */
   observeDeep (f) {
     addEventHandlerListener(this._dEH, f)
@@ -382,7 +382,7 @@ export class AbstractType {
   /**
    * Unregister an observer function.
    *
-   * @param {function(Array<YEvent>,Transaction):void} f Observer function
+   * @param {function(Array<YEvent<any>>,Transaction):void} f Observer function
    */
   unobserveDeep (f) {
     removeEventHandlerListener(this._dEH, f)

--- a/src/types/YArray.js
+++ b/src/types/YArray.js
@@ -23,6 +23,7 @@ import { typeListSlice } from './AbstractType.js'
 /**
  * Event that describes the changes on a YArray
  * @template T
+ * @extends YEvent<YArray<T>>
  */
 export class YArrayEvent extends YEvent {
   /**

--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -21,6 +21,7 @@ import * as iterator from 'lib0/iterator'
 
 /**
  * @template T
+ * @extends YEvent<YMap<T>>
  * Event that describes the changes on a YMap.
  */
 export class YMapEvent extends YEvent {

--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -502,6 +502,7 @@ const deleteText = (transaction, currPos, length) => {
   */
 
 /**
+ * @extends YEvent<YText>
  * Event that describes the changes on a YText type.
  */
 export class YTextEvent extends YEvent {

--- a/src/types/YXmlEvent.js
+++ b/src/types/YXmlEvent.js
@@ -5,6 +5,7 @@ import {
 } from '../internals.js'
 
 /**
+ * @extends YEvent<YXmlElement|YXmlText|YXmlFragment>
  * An Event that describes changes on a YXml Element or Yxml Fragment
  */
 export class YXmlEvent extends YEvent {

--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -48,7 +48,7 @@ export class Doc extends Observable {
     this.guid = guid
     this.collectionid = collectionid
     /**
-     * @type {Map<string, AbstractType<YEvent>>}
+     * @type {Map<string, AbstractType<YEvent<any>>>}
      */
     this.share = new Map()
     this.store = new StructStore()

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -75,13 +75,13 @@ export class Transaction {
      * All types that were directly modified (property added or child
      * inserted/deleted). New types are not included in this Set.
      * Maps from type to parentSubs (`item.parentSub = null` for YArray)
-     * @type {Map<AbstractType<YEvent>,Set<String|null>>}
+     * @type {Map<AbstractType<YEvent<any>>,Set<String|null>>}
      */
     this.changed = new Map()
     /**
      * Stores the events for the types that observe also child elements.
      * It is mainly used by `observeDeep`.
-     * @type {Map<AbstractType<YEvent>,Array<YEvent>>}
+     * @type {Map<AbstractType<YEvent<any>>,Array<YEvent<any>>>}
      */
     this.changedParentTypes = new Map()
     /**
@@ -148,7 +148,7 @@ export const nextID = transaction => {
  * did not change, it was just added and we should not fire events for `type`.
  *
  * @param {Transaction} transaction
- * @param {AbstractType<YEvent>} type
+ * @param {AbstractType<YEvent<any>>} type
  * @param {string|null} parentSub
  */
 export const addChangedTypeToTransaction = (transaction, type, parentSub) => {

--- a/src/utils/YEvent.js
+++ b/src/utils/YEvent.js
@@ -8,17 +8,18 @@ import * as set from 'lib0/set'
 import * as array from 'lib0/array'
 
 /**
+ * @template {AbstractType<any>} T
  * YEvent describes the changes on a YType.
  */
 export class YEvent {
   /**
-   * @param {AbstractType<any>} target The changed type.
+   * @param {T} target The changed type.
    * @param {Transaction} transaction
    */
   constructor (target, transaction) {
     /**
      * The type on which this event was created on.
-     * @type {AbstractType<any>}
+     * @type {T}
      */
     this.target = target
     /**


### PR DESCRIPTION
This PR makes the TypeScript type for `YEvent` subclasses include the accurate type for the `target` property (e.g. `YArray` for `YArrayEvent`, `YText` for `YTextEvent` etc.).

I found this useful for working with `observeDeep` in TypeScript because now I don't need as many casts or `instanceof` tests (e.g. it's enough to verify that `event` is `YMapEvent` without having to assert the type of `event.target` separately).