### PR TITLE
Avoid copying attribute map when deleting

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -465,7 +465,7 @@ const deleteText = (transaction, currPos, length) => {
     currPos.forward()
   }
   if (start) {
-    cleanupFormattingGap(transaction, start, currPos.right, startAttrs, map.copy(currPos.currentAttributes))
+    cleanupFormattingGap(transaction, start, currPos.right, startAttrs, currPos.currentAttributes)
   }
   const parent = /** @type {AbstractType<any>} */ (/** @type {Item} */ (currPos.left || currPos.right).parent)
   if (parent._searchMarker) {

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -143,7 +143,7 @@ export const testNotMergeEmptyLinesFormat = tc => {
  */
 export const testPreserveAttributesThroughDelete = tc => {
   const ydoc = new Y.Doc()
-  const testText = ydoc.getText('test');
+  const testText = ydoc.getText('test')
   testText.applyDelta([
     { insert: 'Text' },
     { insert: '\n', attributes: { title: true } },
@@ -152,11 +152,11 @@ export const testPreserveAttributesThroughDelete = tc => {
   testText.applyDelta([
     { retain: 4 },
     { delete: 1 },
-    { retain: 1, attributes: { title: true } },
+    { retain: 1, attributes: { title: true } }
   ])
   t.compare(testText.toDelta(), [
     { insert: 'Text' },
-    { insert: '\n', attributes: { title: true } },
+    { insert: '\n', attributes: { title: true } }
   ])
 }
 

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -141,6 +141,28 @@ export const testNotMergeEmptyLinesFormat = tc => {
 /**
  * @param {t.TestCase} tc
  */
+export const testPreserveAttributesThroughDelete = tc => {
+  const ydoc = new Y.Doc()
+  const testText = ydoc.getText('test');
+  testText.applyDelta([
+    { insert: 'Text' },
+    { insert: '\n', attributes: { title: true } },
+    { insert: '\n' }
+  ])
+  testText.applyDelta([
+    { retain: 4 },
+    { delete: 1 },
+    { retain: 1, attributes: { title: true } },
+  ])
+  t.compare(testText.toDelta(), [
+    { insert: 'Text' },
+    { insert: '\n', attributes: { title: true } },
+  ])
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
 export const testGetDeltaWithEmbeds = tc => {
   const { text0 } = init(tc, { users: 1 })
   text0.applyDelta([{


### PR DESCRIPTION
Calling cleanupFormattingGap should not make a copy of the
attributes because it needs to be able to update them.

Fixes #305 with the suggestion from @calibr.