### PR TITLE
cleanup redundant text attributes when delete attributes

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -164,6 +164,20 @@ const insertNegatedAttributes = (transaction, parent, currPos, negatedAttributes
   const doc = transaction.doc
   const ownClientId = doc.clientID
   negatedAttributes.forEach((val, key) => {
+    // check if we really need to create attributes
+    //  (the attribute may be set the desired value already)
+    let n = currPos.right
+    while(
+      n !== null && (n.deleted === true || n.content.constructor === ContentFormat)
+    ) {
+      if (!n.deleted && equalAttrs(currPos.currentAttributes.get(/** @type {ContentFormat} */ (n.content).key) ?? null, /** @type {ContentFormat} */ (n.content).value)) {
+        n.delete(transaction)
+        return
+      }
+      n = n.right
+    }
+
+    // create negated attribute
     const left = currPos.left
     const right = currPos.right
     const nextFormat = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentFormat(key, val))

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -607,6 +607,35 @@ export const testFormattingBug = async tc => {
   console.log(text1.toDelta())
 }
 
+/**
+ * Delete formatting should not leave redundant formatting items.
+ *
+ * @param {t.TestCase} tc
+ */
+export const testDeleteFormatting = tc => {
+  const doc = new Y.Doc()
+  const text = doc.getText()
+  text.insert(0, 'Attack ships on fire off the shoulder of Orion.')
+
+  const doc2 = new Y.Doc()
+  const text2 = doc2.getText()
+  Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc))
+
+  text.format(13, 7, { bold: true })
+  Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc))
+
+  text.format(16, 4, { bold: null })
+  Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc))
+
+  const expected = [
+    { insert: 'Attack ships ' },
+    { insert: 'on ', attributes: { bold: true } },
+    { insert: 'fire off the shoulder of Orion.' }
+  ]
+  t.compare(text.toDelta(), expected)
+  t.compare(text2.toDelta(), expected)
+}
+
 // RANDOM TESTS
 
 let charCounter = 0


### PR DESCRIPTION
Fixes #392

I was able to track it down to some redundant formatting that was left from the format function.

I expected that the text contains following contents after Change 2 (`text.format(16, 4, { bold: null })`) from the issue:

```js
ContentString { str: 'Attack ships ' }
ContentFormat { key: 'bold', value: true }
ContentString { str: 'on ' }
ContentFormat { key: 'bold', value: null }
ContentString { str: 'fire' }
ContentString { str: ' off the shoulder of Orion.' }
```

But instead got this contents:

```js
ContentString { str: 'Attack ships ' }
ContentFormat { key: 'bold', value: true }
ContentString { str: 'on ' }
ContentFormat { key: 'bold', value: null }
ContentString { str: 'fire' }
ContentFormat { key: 'bold', value: true } // redundant
ContentFormat { key: 'bold', value: null } // redundant
ContentString { str: ' off the shoulder of Orion.' }
```

Which contains redundant formatting contents.
I added an detection for this which fixes the issue.
