### PR TITLE
add immer-yjs to Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ are implemented in separate modules.
 | [Monaco](https://microsoft.github.io/monaco-editor/) | ✔ | [y-monaco](https://github.com/yjs/y-monaco) | [demo](https://demos.yjs.dev/monaco/monaco.html) |
 | [Slate](https://github.com/ianstormtaylor/slate) | ✔ | [slate-yjs](https://github.com/bitphinix/slate-yjs) | [demo](https://bitphinix.github.io/slate-yjs-example) |
 | [valtio](https://github.com/pmndrs/valtio) |  | [valtio-yjs](https://github.com/dai-shi/valtio-yjs) | [demo](https://codesandbox.io/s/valtio-yjs-demo-ox3iy) |
+| [immer](https://github.com/immerjs/immer) |  | [immer-yjs](https://github.com/sep2/immer-yjs) | [demo](https://codesandbox.io/s/immer-yjs-demo-6e0znb) |
 | React / Vue / Svelte / MobX | | [SyncedStore](https://syncedstore.org) | [demo](https://syncedstore.org/docs/react) |
 
 ### Providers


### PR DESCRIPTION
This PR adds [immer-yjs](https://github.com/sep2/immer-yjs) to Bindings section in readme.md.

`immer-yjs` allows manipulating `y.js` data types with the api provided by `immer`.

* Two-way binding between y.js and plain (nested) json object/array.
* Efficient snapshot update with structural sharing, same as `immer`.
* Updates to `y.js` are explicitly batched in transaction, you control the transaction boundary.
* Always opt-in, non-intrusive by nature (the snapshot is just a plain object after all).
* The snapshot shape & y.js binding aims to be fully customizable.
* Typescript all the way (pure js is also supported).
* Code is simple and small, no magic hidden behind, no vendor-locking.