### PR TITLE
Upgrade lib0 from v0.2.43 to v0.2.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "13.5.29",
       "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.43"
+        "lib0": "^0.2.47"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "homepage": "https://docs.yjs.dev",
   "dependencies": {
-    "lib0": "^0.2.43"
+    "lib0": "^0.2.47"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",


### PR DESCRIPTION
After upgrading to the latest version (13.5.29), I started to see the
following error:

```
ERROR in ./node_modules/yjs/dist/yjs.mjs 4048:13-26
export 'isArray' (imported as 'array') was not found in 'lib0/array' (possible exports: appendTo, copy, create, equalFlat, every, flatten, from, last, some)
```

It looks like `array.isArray` was added to `lib0` in [v0.2.47](https://github.com/dmonad/lib0/releases/tag/v0.2.47).
Updating the version in `package.json` fixed the error in my project.