### PR TITLE
Fix null check issue causing unreadable documents

### DIFF
--- a/src/structs/Item.js
+++ b/src/structs/Item.js
@@ -459,7 +459,7 @@ export class Item extends AbstractStruct {
         // Let c in conflictingItems, b in itemsBeforeOrigin
         // ***{origin}bbbb{this}{c,b}{c,b}{o}***
         // Note that conflictingItems is a subset of itemsBeforeOrigin
-        while (o !== null && o !== this.right) {
+        while (o != null && o !== this.right) {
           itemsBeforeOrigin.add(o)
           conflictingItems.add(o)
           if (compareIDs(this.origin, o.origin)) {


### PR DESCRIPTION
We ran into a problem while using yjs where a stored document binary became unreadable. The stack trace we got is below:

```
org.graalvm.polyglot.PolyglotException: Uncaught TypeError: Cannot read properties of undefined (reading 'origin')
	at <js>.integrate(yjsBackendBundle.js:19628)
	at <js>.integrateStructs(yjsBackendBundle.js:11897)
	at <js>.:=>(yjsBackendBundle.js:11962)
	at <js>.transact(yjsBackendBundle.js:13628)
	at <js>.readUpdateV2(yjsBackendBundle.js:11950)
	at <js>.applyUpdateV2(yjsBackendBundle.js:12045)
	at <js>.applyUpdate(yjsBackendBundle.js:12059)
```

The line numbers above don't make sense because they come from our bundled application but the error originates here: https://github.com/yjs/yjs/blob/a22b3cdbc1ee975c023d78725f521f250b7020c2/src/structs/Item.js#L465. 

Don't understand the context around this code well enough but generally observe that `o` can be undefined and think we should guard against both `null` and `undefined` instead of the strict check against `null`. Let me know if this makes sense @dmonad 