### PR TITLE
Use correct namespace when generating dom nodes for SVG content

### DIFF
--- a/src/types/YXmlElement.js
+++ b/src/types/YXmlElement.js
@@ -201,7 +201,20 @@ export class YXmlElement extends YXmlFragment {
    * @public
    */
   toDOM (_document = document, hooks = {}, binding) {
-    const dom = _document.createElement(this.nodeName)
+    let dom;
+    switch(this.nodeName){
+      case "polyline":
+      case "path":
+      case "rect":
+      case "circle":
+      case "ellipse":
+      case "line":
+      case "svg":
+        dom = _document.createElementNS('http://www.w3.org/2000/svg', this.nodeName);
+        break;
+      default:
+        dom = _document.createElement(this.nodeName);
+    }
     const attrs = this.getAttributes()
     for (const key in attrs) {
       dom.setAttribute(key, attrs[key])


### PR DESCRIPTION
Hey Kevin,

Please let me know if this is equally out of scope as https://github.com/yjs/yjs/pull/341 and we'll retract. However we've found it harder to externally override this method because it's dependency on `typeListForEach` which is not public.

Without this patch `toDOM()` will output SVG content that's not renderable by the browser. 