### PR TITLE
Add support for esm in node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./dist/yjs.mjs",
       "require": "./dist/yjs.cjs"
     },


### PR DESCRIPTION
I'm trying to yjs with TypeScript's experimental support for ECMAScript modules in node.js.
https://www.typescriptlang.org/docs/handbook/esm-node.html

To import the types correctly, we need to add `exports.types` field.
