### PR TITLE
Prefer globalThis over window and global

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,10 +92,12 @@ export {
   convertUpdateFormatV2ToV1
 } from './internals.js'
 
-const glo = /** @type {any} */ (typeof window !== 'undefined'
-  ? window
-  // @ts-ignore
-  : typeof global !== 'undefined' ? global : {})
+const glo = /** @type {any} */ (typeof globalThis !== 'undefined'
+  ? globalThis
+  : typeof window !== 'undefined'
+    ? window
+    // @ts-ignore
+    : typeof global !== 'undefined' ? global : {})
 
 const importIdentifier = '__ $YJS$ __'
 


### PR DESCRIPTION
[globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is the JS standardised version of `global` (Node) and `window` (Browsers). 

This PR makes it so that we select `globalThis` if it's defined. Eventually, when the time comes, `window` and `global` can be removed.

I have no specific use case for this change. I suppose there's probably a JS runtime out that only defines `globalThis`. Just something I noticed as a small improvement while looking through the code.