### PR TITLE
export UpdateEncoderV1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,8 @@ export {
   diffUpdate,
   diffUpdateV2,
   convertUpdateFormatV1ToV2,
-  convertUpdateFormatV2ToV1
+  convertUpdateFormatV2ToV1,
+  UpdateEncoderV1
 } from './internals.js'
 
 const glo = /** @type {any} */ (typeof window !== 'undefined'


### PR DESCRIPTION
Hi @dmonad

In Nimbus we are using `UpdateEncoderV1` but in new release of `yjs` its gone from exports. 
May we return it?

Thank you