### PR TITLE
Make encodeStateAsUpdate deterministic

### DIFF
--- a/src/utils/DeleteSet.js
+++ b/src/utils/DeleteSet.js
@@ -222,7 +222,7 @@ export const writeDeleteSet = (encoder, ds) => {
 
   // Ensure that the delete set is written in a deterministic order
   Array.from(ds.clients.entries())
-    .sort((clientA, clientB) => clientB[0] - clientA[0])
+    .sort((clientA, clientB) => clientA[0] - clientB[0])
     .forEach(([client, dsitems]) => {
       encoder.resetDsCurVal()
       encoding.writeVarUint(encoder.restEncoder, client)

--- a/src/utils/DeleteSet.js
+++ b/src/utils/DeleteSet.js
@@ -219,17 +219,21 @@ export const createDeleteSetFromStructStore = ss => {
  */
 export const writeDeleteSet = (encoder, ds) => {
   encoding.writeVarUint(encoder.restEncoder, ds.clients.size)
-  ds.clients.forEach((dsitems, client) => {
-    encoder.resetDsCurVal()
-    encoding.writeVarUint(encoder.restEncoder, client)
-    const len = dsitems.length
-    encoding.writeVarUint(encoder.restEncoder, len)
-    for (let i = 0; i < len; i++) {
-      const item = dsitems[i]
-      encoder.writeDsClock(item.clock)
-      encoder.writeDsLen(item.len)
-    }
-  })
+
+  // Ensure that the delete set is written in a deterministic order
+  Array.from(ds.clients.entries())
+    .sort((clientA, clientB) => clientB[0] - clientA[0])
+    .forEach(([client, dsitems]) => {
+      encoder.resetDsCurVal()
+      encoding.writeVarUint(encoder.restEncoder, client)
+      const len = dsitems.length
+      encoding.writeVarUint(encoder.restEncoder, len)
+      for (let i = 0; i < len; i++) {
+        const item = dsitems[i]
+        encoder.writeDsClock(item.clock)
+        encoder.writeDsLen(item.len)
+      }
+    })
 }
 
 /**


### PR DESCRIPTION
This PR modifies the encoding of the delete set in `encodeStateAsUpdate` so that the entries are sorted in descending client ID order. 

This makes it possible to perform hash or checksum on the encoded state of a document and get a consistent result across different peers if the states are equivalent.