### PR TITLE
chore: expose `getStateVector` to be used externally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ export {
   decodeSnapshotV2,
   encodeSnapshotV2,
   decodeStateVector,
+  getStateVector,
   logUpdate,
   logUpdateV2,
   decodeUpdate,


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/w-githubdmonad-yjs-660d5772-70f06a0a22-d28cf5?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjBkNjNiOThjN2YzNTBiMTEyMTNlZmEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.yWiYbpsrwgWxBDcs5KEr8IbWgfa1Xbnyw6sKsbWqfr4">Huly&reg;: <b>YJS-432</b></a></sub>