### PR TITLE
Add `encodeStateVectorV2` to list of exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ export {
   encodeStateAsUpdate,
   encodeStateAsUpdateV2,
   encodeStateVector,
+  encodeStateVectorV2,
   UndoManager,
   decodeSnapshot,
   encodeSnapshot,


### PR DESCRIPTION
As mentioned in bug report 441: https://github.com/yjs/yjs/issues/441

The export for encodeStateVectorV2 is missing.
This pr adds it to the list of exported functions in index.js