### PR TITLE
Add y-mongodb-provider to provider list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ your client app and Matrix can provide powerful features like Authentication,
 Authorization, Federation, hosting (self-hosting or SaaS) and even End-to-End
 Encryption (E2EE).
 </dd>
+  <dt><a href="https://github.com/MaxNoetzold/y-mongodb-provider">y-mongodb-provider</a></dt>
+  <dd>
+Adds persistent storage to a server with MongoDB. Can be used with the y-websocket provider.
+</dd>
 </dl>
 
 ## Getting Started


### PR DESCRIPTION
Add my new [MongoDB Provider](https://github.com/MaxNoetzold/y-mongodb-provider) to the provider list in the README file so users can find it if they need one.