### PR TITLE
Remove unused return in `forEach` of `YMap`

### DIFF
--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -167,16 +167,11 @@ export class YMap extends AbstractType {
    * @param {function(MapType,string,YMap<MapType>):void} f A function to execute on every element of this YArray.
    */
   forEach (f) {
-    /**
-     * @type {Object<string,MapType>}
-     */
-    const map = {}
     this._map.forEach((item, key) => {
       if (!item.deleted) {
         f(item.content.getContent()[item.length - 1], key, this)
       }
     })
-    return map
   }
 
   /**


### PR DESCRIPTION
If the idea is to keep the API as close to the JS Map as possible, maybe we should consider not returning here.

Ref: https://github.com/microsoft/TypeScript/blob/v4.8.3/lib/lib.es2015.collection.d.ts#L28-L31