### PR TITLE
Restore deleted entries in a map by the undomanager

### DIFF
--- a/src/structs/Item.js
+++ b/src/structs/Item.js
@@ -200,7 +200,7 @@ export const redoItem = (transaction, item, redoitems, itemsToDelete, ignoreRemo
   } else {
     right = null
     if (item.right && !ignoreRemoteMapChanges) {
-      left = item
+      left = item.right
       // Iterate right while right is in itemsToDelete
       // If it is intended to delete right while item is redone, we can expect that item should replace right.
       while (left !== null && left.right !== null && isDeleted(itemsToDelete, left.right.id)) {

--- a/tests/undo-redo.tests.js
+++ b/tests/undo-redo.tests.js
@@ -647,7 +647,7 @@ export const testSpecialDeletionCase = tc => {
 
 /**
  * Deleted entries in a map should be restored on undo.
- * 
+ *
  * @see https://github.com/yjs/yjs/issues/500
  * @param {t.TestCase} tc
  */
@@ -667,20 +667,19 @@ export const testUndoDeleteInMap = (tc) => {
 
   undoManager.undo()
   t.compare(map0.toJSON(), {})
-  
+
   undoManager.undo()
   t.compare(map0.toJSON(), { a: 'c' })
-  
+
   undoManager.undo()
   t.compare(map0.toJSON(), {})
-  
+
   undoManager.undo()
   t.compare(map0.toJSON(), { a: 'b' })
-  
+
   undoManager.undo()
   t.compare(map0.toJSON(), {})
-  
+
   undoManager.undo()
   t.compare(map0.toJSON(), { a: 'a' })
-};
-
+}

--- a/tests/undo-redo.tests.js
+++ b/tests/undo-redo.tests.js
@@ -644,3 +644,43 @@ export const testSpecialDeletionCase = tc => {
   undoManager.undo()
   t.compareStrings(fragment.toString(), '<test a="1" b="2"></test>')
 }
+
+/**
+ * Deleted entries in a map should be restored on undo.
+ * 
+ * @see https://github.com/yjs/yjs/issues/500
+ * @param {t.TestCase} tc
+ */
+export const testUndoDeleteInMap = (tc) => {
+  const { map0 } = init(tc, { users: 3 })
+  const undoManager = new Y.UndoManager(map0, { captureTimeout: 0 })
+
+  map0.set('a', 'a')
+  map0.delete('a')
+  map0.set('a', 'b')
+  map0.delete('a')
+  map0.set('a', 'c')
+  map0.delete('a')
+  map0.set('a', 'd')
+
+  t.compare(map0.toJSON(), { a: 'd' })
+
+  undoManager.undo()
+  t.compare(map0.toJSON(), {})
+  
+  undoManager.undo()
+  t.compare(map0.toJSON(), { a: 'c' })
+  
+  undoManager.undo()
+  t.compare(map0.toJSON(), {})
+  
+  undoManager.undo()
+  t.compare(map0.toJSON(), { a: 'b' })
+  
+  undoManager.undo()
+  t.compare(map0.toJSON(), {})
+  
+  undoManager.undo()
+  t.compare(map0.toJSON(), { a: 'a' })
+};
+


### PR DESCRIPTION
Fixes #500

This issue occurred in our data structure where we store a "lock" of an object. This is can be enabled/disabled by the user but a repeated toggle couldn't be undo'd. The test still works in version 13.5.24 and was broken since https://github.com/yjs/yjs/commit/4cfa49d601743e4366109b6e800125322b5c147a.

I find it suspicious that `item.right` is checked for existence but then nothing is done with it. All the other tests still work, so I hope this doesn't introduce new bugs.