### PR TITLE
Change cleanupTransactions to avoid call stack overflow

### DIFF
--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -242,7 +242,7 @@ export const tryGc = (ds, store, gcFilter) => {
  * @param {number} i
  */
 const cleanupTransactions = (transactionCleanups, i) => {
-  if (i < transactionCleanups.length) {
+  while (i < transactionCleanups.length) {
     const transaction = transactionCleanups[i]
     const doc = transaction.doc
     const store = doc.store
@@ -363,11 +363,9 @@ const cleanupTransactions = (transactionCleanups, i) => {
         subdocsRemoved.forEach(subdoc => subdoc.destroy())
       }
 
-      if (transactionCleanups.length <= i + 1) {
+      if (transactionCleanups.length <= ++i) {
         doc._transactionCleanups = []
         doc.emit('afterAllTransactions', [doc, transactionCleanups])
-      } else {
-        cleanupTransactions(transactionCleanups, i + 1)
       }
     }
   }


### PR DESCRIPTION
This PR fixes a bug in `cleanupTransactions()` that causes the call stack to overflow when loading a large Y.Doc.  The fix is to change that function from a recursive function to an iterative function so that it can never overflow the call stack no matter how many cleanups are needed.

There is a full description of the bug in #522.

Closes #522