### PR TITLE
Add missing getting-started steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ PORT=1234 node ./node_modules/y-websocket/bin/server.js
 ### Example: Observe types
 
 ```js
+import * as Y from 'yjs';
+
+const doc = new Y.Doc();
 const yarray = doc.getArray('my-array')
 yarray.observe(event => {
   console.log('yarray was modified')


### PR DESCRIPTION
The 'getting started' doesn't work without importing and creating the first doc.