### PR TITLE
Fix retains for embedded types in YTextEvent

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -625,6 +625,10 @@ export class YTextEvent extends YEvent {
          */
         let insert = ''
         let retain = 0
+        /**
+         * @type {string?}
+         */
+        let retainType = null;
         let deleteLen = 0
         const addOp = () => {
           if (action !== null) {
@@ -656,8 +660,10 @@ export class YTextEvent extends YEvent {
               case 'retain':
                 if (retain > 0) {
                   op = { retain }
-                  if (!object.isEmpty(attributes)) {
-                    op.attributes = object.assign({}, attributes)
+                  if (retainType === 'ContentString') {
+                    if (!object.isEmpty(attributes)) {
+                      op.attributes = object.assign({}, attributes)
+                    }
                   }
                 }
                 retain = 0
@@ -685,9 +691,10 @@ export class YTextEvent extends YEvent {
                 }
                 deleteLen += 1
               } else if (!item.deleted) {
-                if (action !== 'retain') {
+                if (action !== 'retain' || retainType !== 'ContentEmbed') {
                   addOp()
                   action = 'retain'
+                  retainType = 'ContentEmbed'
                 }
                 retain += 1
               }
@@ -708,9 +715,10 @@ export class YTextEvent extends YEvent {
                 }
                 deleteLen += item.length
               } else if (!item.deleted) {
-                if (action !== 'retain') {
+                if (action !== 'retain' || retainType !== 'ContentString') {
                   addOp()
                   action = 'retain'
+                  retainType = 'ContentString'
                 }
                 retain += item.length
               }

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -1676,6 +1676,29 @@ export const testDeltaAfterConcurrentFormatting = tc => {
 /**
  * @param {t.TestCase} tc
  */
+export const testDeltaAfterDelete = tc => {
+  const { text0, text1, testConnector } = init(tc, { users: 2 })
+  text0.insert(0, 'abc', {bold: true});
+  text0.insertEmbed(3, new Y.Map([['key', 'val']]));
+  testConnector.flushAllMessages()
+  /**
+   * @type {any}
+   */
+  const deltas = []
+  text1.observe(event => {
+    if (event.delta.length > 0) {
+      deltas.push(event.delta)
+    }
+  })
+  text0.delete(0, 3);
+  testConnector.flushAllMessages()
+  console.error("The actual deltas", deltas);
+  t.compare(deltas, [[{ delete: 3}]])
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
 export const testBasicInsertAndDelete = tc => {
   const { users, text0 } = init(tc, { users: 2 })
   let delta

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -1674,6 +1674,11 @@ export const testDeltaAfterConcurrentFormatting = tc => {
 }
 
 /**
+ * Check if the delta is correct after a delete operation. Specifically, we want to make sure that
+ * an embed following the deleted text does not get an attribute update.
+ * 
+ * See https://github.com/yjs/yjs/issues/529
+ * 
  * @param {t.TestCase} tc
  */
 export const testDeltaAfterDelete = tc => {
@@ -1692,7 +1697,28 @@ export const testDeltaAfterDelete = tc => {
   })
   text0.delete(0, 3);
   testConnector.flushAllMessages()
-  console.error("The actual deltas", deltas);
+  t.compare(deltas, [[{ delete: 3}]])
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testDeltaAfterDeleteWithText = tc => {
+  const { text0, text1, testConnector } = init(tc, { users: 2 })
+  text0.insert(0, 'abc', {bold: true});
+  text0.insert(3, 'def');
+  testConnector.flushAllMessages()
+  /**
+   * @type {any}
+   */
+  const deltas = []
+  text1.observe(event => {
+    if (event.delta.length > 0) {
+      deltas.push(event.delta)
+    }
+  })
+  text0.delete(0, 3);
+  testConnector.flushAllMessages()
   t.compare(deltas, [[{ delete: 3}]])
 }
 

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -1703,6 +1703,33 @@ export const testDeltaAfterDelete = tc => {
 /**
  * @param {t.TestCase} tc
  */
+export const testDeltaAfterDeleteWithEmbedInsideText = tc => {
+  const { text0, text1, testConnector } = init(tc, { users: 2 })
+  const p1 = new Y.XmlText();
+  p1.setAttribute("type", "paragraph")
+  p1.insert(0, "p1")
+  
+  text0.insert(0, "abc", {bold: true});
+  text0.insert(3, "defghi", {bold: false});
+  text0.insertEmbed(6, p1);
+  testConnector.flushAllMessages()
+  /**
+   * @type {any}
+   */
+  const deltas = []
+  text1.observe(event => {
+    if (event.delta.length > 0) {
+      deltas.push(event.delta)
+    }
+  })
+  text0.delete(3, 3);
+  testConnector.flushAllMessages()
+  t.compare(deltas, [[{retain: 3}, { delete: 3}]])
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
 export const testDeltaAfterDeleteWithText = tc => {
   const { text0, text1, testConnector } = init(tc, { users: 2 })
   text0.insert(0, 'abc', {bold: true});


### PR DESCRIPTION
Don't include attributes in retains for embedded types since they're not subject to formatting

This fixes https://github.com/yjs/yjs/issues/529