### PR TITLE
group cleanups for YText changes into a single transaction

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -859,12 +859,21 @@ export class YText extends AbstractType {
   _callObserver (transaction, parentSubs) {
     super._callObserver(transaction, parentSubs)
     const event = new YTextEvent(this, transaction, parentSubs)
-    const doc = transaction.doc
     callTypeObservers(this, transaction, event)
     // If a remote change happened, we try to cleanup potential formatting duplicates.
     if (!transaction.local) {
+      transaction._yTexts.push(this)
+    }
+  }
+
+  /**
+   * @param {Transaction} transaction
+   */
+  _cleanup (transaction) {
+    if (!transaction.local) {
       // check if another formatting item was inserted
       let foundFormattingItem = false
+      const doc = transaction.doc
       for (const [client, afterClock] of transaction.afterState.entries()) {
         const clock = transaction.beforeState.get(client) || 0
         if (afterClock === clock) {

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -11,7 +11,7 @@ import {
   Item,
   generateNewClientId,
   createID,
-  UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
+  UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc, YText // eslint-disable-line
 } from '../internals.js'
 
 import * as map from 'lib0/map'
@@ -114,6 +114,10 @@ export class Transaction {
      * @type {Set<Doc>}
      */
     this.subdocsLoaded = new Set()
+    /**
+     * @type {Array<YText>}
+     */
+    this._yTexts = []
   }
 }
 
@@ -295,6 +299,13 @@ const cleanupTransactions = (transactionCleanups, i) => {
         fs.push(() => doc.emit('afterTransaction', [transaction, doc]))
       })
       callAll(fs, [])
+      if (transaction._yTexts.length > 0) {
+        transact(doc, () => {
+          transaction._yTexts.forEach(yText => {
+            yText._cleanup(transaction)
+          })
+        })
+      }
     } finally {
       // Replace deleted items with ItemDeleted / GC.
       // This is where content is actually remove from the Yjs Doc.


### PR DESCRIPTION
Fixes #522 but is still massively slow