### PR TITLE
mark structs as merged and filter out at the end of bulk operations

### DIFF
--- a/src/utils/StructStore.js
+++ b/src/utils/StructStore.js
@@ -112,6 +112,9 @@ export const addStruct = (store, struct) => {
 export const findIndexSS = (structs, clock) => {
   let left = 0
   let right = structs.length - 1
+  while (/** @type any */(structs[right])._wasMerged) {
+    right--
+  }
   let mid = structs[right]
   let midclock = mid.id.clock
   if (midclock === clock) {
@@ -126,6 +129,9 @@ export const findIndexSS = (structs, clock) => {
     midclock = mid.id.clock
     if (midclock <= clock) {
       if (clock < midclock + mid.length) {
+        while (/** @type any */(structs[midindex])._wasMerged) {
+          midindex--
+        }
         return midindex
       }
       left = midindex + 1

--- a/src/utils/StructStore.js
+++ b/src/utils/StructStore.js
@@ -112,7 +112,7 @@ export const addStruct = (store, struct) => {
 export const findIndexSS = (structs, clock) => {
   let left = 0
   let right = structs.length - 1
-  while (/** @type any */(structs[right])._wasMerged) {
+  while (right > 0 && structs[right] === structs[right - 1]) {
     right--
   }
   let mid = structs[right]
@@ -129,7 +129,7 @@ export const findIndexSS = (structs, clock) => {
     midclock = mid.id.clock
     if (midclock <= clock) {
       if (clock < midclock + mid.length) {
-        while (/** @type any */(structs[midindex])._wasMerged) {
+        while (midindex > 0 && structs[midindex] === structs[midindex - 1]) {
           midindex--
         }
         return midindex

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -184,24 +184,21 @@ const tryToMergeWithLeft = (structs, pos) => {
  * @param {Array<AbstractStruct>} structs
  * @param {number} pos
  */
-const tryToMergeWithLeftNoSplice = (structs, pos) => {
+export const tryToMergeWithLeftNoSplice = (structs, pos) => {
+  const left = structs[pos - 1]
   const right = structs[pos]
-  if (/** @type any */(right)._wasMerged) {
+  if (left === right) {
     return 0
   }
-  let offset = 1
-  let left
-  do {
-    left = structs[pos - offset++]
-  } while (/** @type any */(left)._wasMerged)
   if (left.deleted === right.deleted && left.constructor === right.constructor) {
     if (left.mergeWith(right)) {
-      /** @type any */(right)._wasMerged = true
       if (right instanceof Item && right.parentSub !== null && /** @type {AbstractType<any>} */ (right.parent)._map.get(right.parentSub) === right) {
         /** @type {AbstractType<any>} */ (right.parent)._map.set(right.parentSub, /** @type {Item} */ (left))
       }
-      right.id = left.id
-      right.length = left.length
+      let rightPos = pos
+      while (structs[rightPos] === right) {
+        structs[rightPos++] = left
+      }
       return 1
     }
   }
@@ -215,7 +212,7 @@ const tryToMergeWithLeftNoSplice = (structs, pos) => {
 const filterMergedStructs = (structs, mergedCount) => {
   let from = 0
   for (let to = 0; to < structs.length - mergedCount; to++) {
-    while (/** @type any */(structs[from])._wasMerged) {
+    while (structs[from] === structs[from - 1]) {
       from++
     }
     structs[to] = structs[from]


### PR DESCRIPTION
instead of splicing out of the array immediately
Fixes #541