### PR TITLE
fix: Improve the getAttributes method implementation

### DIFF
--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -877,19 +877,28 @@ export const typeMapGet = (parent, key) => {
 
 /**
  * @param {AbstractType<any>} parent
+ * @param {Snapshot} [snapshot]
  * @return {Object<string,Object<string,any>|number|null|Array<any>|string|Uint8Array|AbstractType<any>|undefined>}
  *
  * @private
  * @function
  */
-export const typeMapGetAll = (parent) => {
+export const typeMapGetAll = (parent, snapshot) => {
   /**
    * @type {Object<string,any>}
    */
   const res = {}
+  const isItemExist = parent._item && isVisible(parent._item, snapshot)
   parent._map.forEach((value, key) => {
-    if (!value.deleted) {
-      res[key] = value.content.getContent()[value.length - 1]
+    /**
+     * @type {Item|null}
+     */
+    let item = value
+    while (isItemExist && item && !isVisible(item, snapshot)) {
+      item = item.left
+    }
+    if (item) {
+      res[key] = item.content.getContent()[item.length - 1]
     }
   })
   return res

--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -1259,12 +1259,14 @@ export class YText extends AbstractType {
    *
    * @note Xml-Text nodes don't have attributes. You can use this feature to assign properties to complete text-blocks.
    *
+   * @param {Snapshot} [snapshot]
+   *
    * @return {Object<string, any>} A JSON Object that describes the attributes.
    *
    * @public
    */
-  getAttributes () {
-    return typeMapGetAll(this)
+  getAttributes (snapshot) {
+    return typeMapGetAll(this, snapshot)
   }
 
   /**

--- a/src/types/YXmlElement.js
+++ b/src/types/YXmlElement.js
@@ -10,7 +10,7 @@ import {
   typeMapGetAll,
   typeListForEach,
   YXmlElementRefID,
-  YXmlText, ContentType, AbstractType, UpdateDecoderV1, UpdateDecoderV2, UpdateEncoderV1, UpdateEncoderV2, Doc, Item // eslint-disable-line
+  YXmlText, ContentType, AbstractType, UpdateDecoderV1, UpdateDecoderV2, UpdateEncoderV1, UpdateEncoderV2, Doc, Item, Snapshot // eslint-disable-line
 } from '../internals.js'
 
 /**
@@ -192,12 +192,14 @@ export class YXmlElement extends YXmlFragment {
   /**
    * Returns all attribute name/value pairs in a JSON Object.
    *
+   * @param {Snapshot} [snapshot]
+   *
    * @return {{ [Key in Extract<keyof KV,string>]?: KV[Key]}} A JSON Object that describes the attributes.
    *
    * @public
    */
-  getAttributes () {
-    return /** @type {any} */ (typeMapGetAll(this))
+  getAttributes (snapshot) {
+    return /** @type {any} */ (typeMapGetAll(this, snapshot))
   }
 
   /**


### PR DESCRIPTION
Our ProseMirror project uses the `renderSnapshot` API to implement the history comparison feature. However, I found that the `getAttrbutes` method is called in the [sync-plugin file](https://github.com/yjs/y-prosemirror/blob/master/src/plugins/sync-plugin.js#L662), which obtains attributes based on the snapshot.It seems that this method has not been fully implemented, so I have completed its implementation.