### PR TITLE
fix: left might be GC

### DIFF
--- a/src/structs/GC.js
+++ b/src/structs/GC.js
@@ -11,16 +11,6 @@ export const structGCRefNumber = 0
  * @private
  */
 export class GC extends AbstractStruct {
-  /**
-   * @param {ID} id
-   * @param {number} length
-   */
-  constructor (id, length) {
-    super(id, length)
-    this.left = null
-    this.right = null
-  }
-
   get deleted () {
     return true
   }

--- a/src/structs/GC.js
+++ b/src/structs/GC.js
@@ -11,6 +11,16 @@ export const structGCRefNumber = 0
  * @private
  */
 export class GC extends AbstractStruct {
+  /**
+   * @param {ID} id
+   * @param {number} length
+   */
+  constructor (id, length) {
+    super(id, length)
+    this.left = null
+    this.right = null
+  }
+
   get deleted () {
     return true
   }

--- a/src/structs/Item.js
+++ b/src/structs/Item.js
@@ -427,9 +427,12 @@ export class Item extends AbstractStruct {
     if (this.parent) {
       if ((!this.left && (!this.right || this.right.left !== null)) || (this.left && this.left.right !== this.right)) {
         /**
-         * @type {Item|null}
+         * @type {GC|Item|null}
          */
         let left = this.left
+        if (left && left.constructor === GC) {
+          left = null
+        }
 
         /**
          * @type {Item|null}


### PR DESCRIPTION
This case happened in `mergeUpdates` API. I'm not sure how to reproduce this, but I'm pretty sure `this.left` could be `GC`

Fixes: https://github.com/yjs/yjs/issues/558