### PR TITLE
fix: switch to uint53 for generateNewClientId

### DIFF
--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -19,7 +19,7 @@ import * as map from 'lib0/map'
 import * as array from 'lib0/array'
 import * as promise from 'lib0/promise'
 
-export const generateNewClientId = random.uint32
+export const generateNewClientId = random.uint53
 
 /**
  * @typedef {Object} DocOpts


### PR DESCRIPTION
This change would bring the code in sync with the documentation here: https://github.com/yjs/yjs/blob/main/INTERNALS.md?plain=1#L27-L29

An alternative could be to fix the documentation. Happy to do that as well in case the current code should be kept