### PR TITLE
fix clientID description (53bit to 32bit)

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -25,8 +25,7 @@ article](https://blog.kevinjahns.de/are-crdts-suitable-for-shared-editing/).
   all other duplicates for each key are flagged as deleted.
 
 Each client is assigned a unique *clientID* property on first insert. This is a
-random 53-bit integer (53 bits because that fits in the javascript safe integer
-range).
+random 32-bit integer (32 bits fits in the javascript safe integer range).
 
 ## List items
 


### PR DESCRIPTION
Initially I thought we can switch to the 53 space and opened a PR https://github.com/yjs/yjs/pull/572, but then realized that this breaks Awareness since there the assumption is that the `clientID` is 32bits due the use of `readVarUint`