### PR TITLE
Only emit "load" when sync is set to true

### DIFF
--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -113,7 +113,7 @@ export class Doc extends Observable {
         this.whenSynced = provideSyncedPromise()
       }
       this.isSynced = isSynced === undefined || isSynced === true
-      if (!this.isLoaded) {
+      if (this.isSynced && !this.isLoaded) {
         this.emit('load', [])
       }
     })


### PR DESCRIPTION
This PR fixes an issue when we use `doc.emit('sync', [false])`, at the moment, it'll emit `load` and change `isLoaded` to `true`.

In our case, we call `doc.emit('sync', [false])` when our socket connection is dropped; and sometimes it can happen before the first time we called `doc.emit('sync', [true])`.

The alternative to this PR is to change the logic of the `sync` event to not accept an argument and to behave like the `load` event where calling it always set the state to true.

The workaround at the moment is to make sure to wrap `doc.emit('sync', [false])`  with `if (doc.isSynced) { }`.