### PR TITLE
feat: expose some types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,10 @@ export {
   Item,
   AbstractStruct,
   GC,
+  Skip,
   ContentBinary,
   ContentDeleted,
+  ContentDoc,
   ContentEmbed,
   ContentFormat,
   ContentJSON,
@@ -93,6 +95,9 @@ export {
   obfuscateUpdate,
   obfuscateUpdateV2,
   UpdateEncoderV1,
+  UpdateEncoderV2,
+  UpdateDecoderV1,
+  UpdateDecoderV2,
   equalDeleteSets,
   snapshotContainsUpdate
 } from './internals.js'


### PR DESCRIPTION
I'm trying to implement some end-to-end encryption updates, like `encryptUpdate(update, private) -> update,` that allows the server to merge updates and decode updates...(just like `obfuscateUpdate`), but the difference is contents are encrypted by `privateKey.` So that it can be safely saved to the server, but the update is still valid so that the server can validate if the document schema is correct.

Then, I found that some internal classes are not exposed, so it will make things hard to extend the existing logic. I would appreciate it if some internal types could be exposed to the downstream so that we can make the ecosystem better.