### PR TITLE
Add support for async functions inside `doc.transact`

### DIFF
--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -436,7 +436,13 @@ export const transact = (doc, f, origin = null, local = true) => {
         // observes throw errors.
         // This file is full of hacky try {} finally {} blocks to ensure that an
         // event can throw errors and also that the cleanup is called.
-        cleanupTransactions(transactionCleanups, 0)
+        if (typeof result?.then === 'function' && result?.constructor?.name === 'Promise') {
+          result.then(() => {
+            cleanupTransactions(transactionCleanups, 0)
+          })
+        } else {
+          cleanupTransactions(transactionCleanups, 0)
+        }
       }
     }
   }


### PR DESCRIPTION
Transact will wait for the async function passed to `transact` to complete before cleaning up the transaction

My use case is streaming text words 1 by 1 with some exceptions were i need to group many updates in 1, without support for async functions inside transactions this is impossible