### PR TITLE
Add top-level getXmlElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,8 @@ type. Doesn't log types that have not been defined (using
   <dd>Define a shared Y.Map type. Is equivalent to <code>y.get(string, Y.Map)</code>.</dd>
   <b><code>getText(string):Y.Text</code></b>
   <dd>Define a shared Y.Text type. Is equivalent to <code>y.get(string, Y.Text)</code>.</dd>
+  <b><code>getXmlElement(string, string):Y.XmlElement</code></b>
+  <dd>Define a shared Y.XmlElement type. Is equivalent to <code>y.get(string, Y.XmlElement)</code>.</dd>
   <b><code>getXmlFragment(string):Y.XmlFragment</code></b>
   <dd>Define a shared Y.XmlFragment type. Is equivalent to <code>y.get(string, Y.XmlFragment)</code>.</dd>
   <b><code>on(string, function)</code></b>

--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -8,6 +8,7 @@ import {
   YArray,
   YText,
   YMap,
+  YXmlElement,
   YXmlFragment,
   transact,
   ContentDoc, Item, Transaction, YEvent // eslint-disable-line
@@ -260,6 +261,17 @@ export class Doc extends Observable {
   getMap (name = '') {
     // @ts-ignore
     return this.get(name, YMap)
+  }
+
+  /**
+   * @param {string} [name]
+   * @return {YXmlElement}
+   *
+   * @public
+   */
+  getXmlElement (name = '') {
+    // @ts-ignore
+    return this.get(name, YXmlElement)
   }
 
   /**

--- a/tests/y-xml.tests.js
+++ b/tests/y-xml.tests.js
@@ -210,3 +210,16 @@ export const testFormattingBug = _tc => {
   yxml.applyDelta(delta)
   t.compare(yxml.toDelta(), delta)
 }
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testElement = _tc => {
+  const ydoc = new Y.Doc()
+  const yxmlel = ydoc.getXmlElement()
+
+  const text1 = new Y.XmlText('text1')
+  const text2 = new Y.XmlText('text2')
+  yxmlel.insert(0, [text1, text2])
+  t.compareArrays(yxmlel.toArray(), [text1, text2])
+}


### PR DESCRIPTION
All shared types have top-level getters except `YXmlElement`. 

This PR adds `getXmlElement` to the `Doc` class.

```js
const doc = new Y.Doc()
const yxmlel = ydoc.getXmlElement('prop-name')
```

Reference:

- https://discuss.yjs.dev/t/why-does-the-ydoc-getxmlelement-method-not-exist/2249