### PR TITLE
Improve types for map public interface

### DIFF
--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -65,7 +65,7 @@ export class YMapEvent extends YEvent {
  * A shared Map implementation.
  *
  * @extends AbstractType<YMapEvent<MapType>>
- * @implements {Iterable<[string, MapType]>}
+ * @implements {Iterable<[StringKey<MapType>, MapType[StringKey<MapType>]]>}
  */
 export class YMap extends AbstractType {
   /**
@@ -176,7 +176,7 @@ export class YMap extends AbstractType {
   /**
    * Returns the values for each element in the YMap Type.
    *
-   * @return {IterableIterator<MapType>}
+   * @return {IterableIterator<MapType[keyof MapType]>}
    */
   values () {
     return iterator.iteratorMap(createMapIterator(this._map), /** @param {any} v */ v => v[1].content.getContent()[v[1].length - 1])
@@ -185,7 +185,7 @@ export class YMap extends AbstractType {
   /**
    * Returns an Iterator of [key, value] pairs
    *
-   * @return {IterableIterator<[string, MapType]>}
+   * @return {IterableIterator<[StringKey<MapType>, MapType[StringKey<MapType>]]>}
    */
   entries () {
     return iterator.iteratorMap(createMapIterator(this._map), /** @param {any} v */ v => /** @type {any} */ ([v[0], v[1].content.getContent()[v[1].length - 1]]))
@@ -207,7 +207,7 @@ export class YMap extends AbstractType {
   /**
    * Returns an Iterator of [key, value] pairs
    *
-   * @return {IterableIterator<[string, MapType]>}
+   * @return {IterableIterator<[StringKey<MapType>, MapType[StringKey<MapType>]]>}
    */
   [Symbol.iterator] () {
     return this.entries()

--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -139,11 +139,11 @@ export class YMap extends AbstractType {
   /**
    * Transforms this Shared Type to a JSON object.
    *
-   * @return {Object<string,any>}
+   * @return {Partial<MapType>}
    */
   toJSON () {
     /**
-     * @type {Object<string,MapType>}
+     * @type {any}
      */
     const map = {}
     this._map.forEach((item, key) => {

--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -30,7 +30,7 @@ import * as iterator from 'lib0/iterator'
 /**
  * @template T
  * @typedef {readonly {
- *            [K in keyof T]: [K, T[K]];
+ *            [K in StringKey<T>]: [K, T[K]];
  *          }[StringKey<T>][]} EntriesOf<T>
  *
  * Converts an object schema into a readonly array containing valid key-value pairs.

--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -40,7 +40,7 @@ import * as iterator from 'lib0/iterator'
  * @typedef {boolean|null|string|number|Uint8Array|JsonArray|JsonObject} Json
  * @typedef {Json[]} JsonArray
  * @typedef {{ [key: string]: Json }} JsonObject
- * @typedef {Json|AbstractType<any>} MapValue
+ * @typedef {Json|AbstractType<any>|Doc} MapValue
  */
 
 /**

--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -251,14 +251,14 @@ export class Doc extends Observable {
   }
 
   /**
-   * @template T
+   * @template {Record<string, import("../internals.js").MapValue>} T
    * @param {string} [name]
    * @return {YMap<T>}
    *
    * @public
    */
   getMap (name = '') {
-    return /** @type {YMap<T>} */ (this.get(name, YMap))
+    return /** @type {YMap<T>} */ /** @type {any} */ (this.get(name, YMap))
   }
 
   /**

--- a/tests/doc.tests.js
+++ b/tests/doc.tests.js
@@ -114,6 +114,7 @@ export const testSubdoc = _tc => {
     doc.on('subdocs', subdocs => {
       event = [Array.from(subdocs.added).map(x => x.guid), Array.from(subdocs.removed).map(x => x.guid), Array.from(subdocs.loaded).map(x => x.guid)]
     })
+    /** @type {Y.Map<{ a: Y.Doc; b: Y.Doc, c: Y.Doc; }>} */
     const subdocs = doc.getMap('mysubdocs')
     const docA = new Y.Doc({ guid: 'a' })
     docA.load()
@@ -121,18 +122,18 @@ export const testSubdoc = _tc => {
     t.compare(event, [['a'], [], ['a']])
 
     event = null
-    subdocs.get('a').load()
+    subdocs.get('a')?.load()
     t.assert(event === null)
 
     event = null
-    subdocs.get('a').destroy()
+    subdocs.get('a')?.destroy()
     t.compare(event, [['a'], ['a'], []])
-    subdocs.get('a').load()
+    subdocs.get('a')?.load()
     t.compare(event, [[], [], ['a']])
 
     subdocs.set('b', new Y.Doc({ guid: 'a', shouldLoad: false }))
     t.compare(event, [['a'], [], []])
-    subdocs.get('b').load()
+    subdocs.get('b')?.load()
     t.compare(event, [[], [], ['a']])
 
     const docC = new Y.Doc({ guid: 'c' })
@@ -156,7 +157,9 @@ export const testSubdoc = _tc => {
     Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc))
     t.compare(event, [['a', 'a', 'c'], [], []])
 
-    doc2.getMap('mysubdocs').get('a').load()
+    /** @type {Y.Map<Record<string, Y.Doc>>} */
+    const mysubdocs = doc2.getMap('mysubdocs')
+    mysubdocs.get('a')?.load()
     t.compare(event, [[], [], ['a']])
 
     t.compare(Array.from(doc2.getSubdocGuids()), ['a', 'c'])

--- a/tests/test-types.ts
+++ b/tests/test-types.ts
@@ -1,0 +1,92 @@
+/**
+ * This file serves to validate the public TypeScript API for YJS.
+ *
+ * It is not included in `npm run lint` or any other automated type checking, but can be used
+ * by those working on YJS types to ensure that the public-facing type interface remains valid.
+ *
+ * Any lines which are supposed to demonstrate statements that _would_ generate type errors
+ * should be clearly marked with the type error that is expected to result, to provide a
+ * negative test case.
+ */
+
+import * as Y from "../dist/src/index";
+
+/*
+ * Typed maps
+ *
+ * - Key names are autocompleted in first parameter of `get` and `set`.
+ * - `MapType` value types are constrained to valid Y.Map contents.
+ */
+type MyType = {
+  foo: string;
+  bar: number | null;
+  baz?: boolean;
+};
+
+// Constructor argument keys & values are typechecked, and keys are autocompleted.
+// Multiple items for each key and partial initialization are allowed.
+const map = new Y.Map<MyType>([
+  ["foo", ""],
+  ["foo", "even better"],
+  // ERROR: Type '["baz", number]' is not assignable to type '["foo", string] | ["bar", number | null] | ["baz", boolean | undefined]'.
+  ["baz", 3],
+]);
+
+// Entries are still allowed to be omitted, so get() still returns <type> | undefined.
+const defaultMap = new Y.Map<MyType>();
+
+// `json` has a type of `Partial<MyType>`
+const json = defaultMap.toJSON();
+
+// string | undefined
+const fooValue = map.get("foo");
+// literal "hi" (string)
+const fooSet = map.set("foo", "hi");
+// number | null | undefined
+const barValue = map.get("bar");
+// ERROR: Argument of type '"hi"' is not assignable to parameter of type 'number | null'.
+const barSet = map.set("bar", "hi");
+// ERROR: Argument of type '"bomb"' is not assignable to parameter of type 'keyof MyType'.
+const missingGet = map.get("bomb");
+// Escape hatch: get<any>()
+const migrateGet = map.get<any>("extraneousKey");
+
+// ERROR: Type '<type>' does not satisfy the constraint 'Record<string, MapValue>'.
+const invalidMap = new Y.Map<{ invalid: () => void }>();
+const invalidMap2 = new Y.Map<{ invalid: Blob }>();
+// Arbitrarily complex valid types are still allowed
+type ComplexType = {
+  n: null;
+  b: boolean;
+  s: string;
+  i: number;
+  u: Uint8Array;
+  a: null | boolean | string | number | Uint8Array[];
+};
+const complexValidType = new Y.Map<
+  ComplexType & { nested: ComplexType & { deeper: ComplexType[] } }
+>();
+
+/*
+ * Default behavior
+ *
+ * Provides basic typechecking over the range of possible map values.
+ */
+const untyped = new Y.Map();
+
+// MapValue | undefined
+const boop = untyped.get("default");
+// Still validates value types: ERROR: Argument of type '() => string' is not assignable to parameter of type 'MapValue'.
+const moop = untyped.set("anything", () => "whoops");
+
+/*
+ * `any` maps (bypass typechecking)
+ */
+const anyMap = new Y.Map<any>();
+
+// any
+const fooValueAny = anyMap.get("foo");
+// literal "hi" (string)
+const fooSetAny = anyMap.set("foo", "hi");
+// Allowed because `any` unlocks cowboy mode
+const barSetAny = anyMap.set("bar", () => "hi");

--- a/tests/undo-redo.tests.js
+++ b/tests/undo-redo.tests.js
@@ -329,6 +329,7 @@ export const testUndoUntilChangePerformed = _tc => {
   const yMap = new Y.Map()
   yMap.set('hello', 'world')
   yArray.push([yMap])
+  /** @type {Y.Map<{ key: string }>} */
   const yMap2 = new Y.Map()
   yMap2.set('key', 'value')
   yArray.push([yMap2])
@@ -342,7 +343,7 @@ export const testUndoUntilChangePerformed = _tc => {
   Y.transact(doc2, () => yArray2.delete(0), doc2.clientID)
   undoManager2.undo()
   undoManager.undo()
-  t.compareStrings(yMap2.get('key'), 'value')
+  t.compareStrings(yMap2.get('key') || '', 'value')
 }
 
 /**

--- a/tests/undo-redo.tests.js
+++ b/tests/undo-redo.tests.js
@@ -448,6 +448,7 @@ export const testUndoNestedUndoIssue = _tc => {
  */
 export const testConsecutiveRedoBug = _tc => {
   const doc = new Y.Doc()
+  /** @type {Y.Map<Record<string, Y.Map<any>>>} */
   const yRoot = doc.getMap()
   const undoMgr = new Y.UndoManager(yRoot)
 
@@ -481,7 +482,7 @@ export const testConsecutiveRedoBug = _tc => {
   t.compare(yRoot.get('a'), undefined)
 
   undoMgr.redo() // x=0, y=0
-  yPoint = yRoot.get('a')
+  yPoint = yRoot.get('a') || new Y.Map()
 
   t.compare(yPoint.toJSON(), { x: 0, y: 0 })
   undoMgr.redo() // x=100, y=100

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -14,7 +14,7 @@ import * as prng from 'lib0/prng'
 export const testIterators = _tc => {
   const ydoc = new Y.Doc()
   /**
-   * @type {Y.Map<number>}
+   * @type {Y.Map<Record<string, number>>}
    */
   const ymap = ydoc.getMap()
   // we are only checking if the type assumptions are correct

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -19,14 +19,16 @@ export const testMapHavingIterableAsConstructorParamTests = tc => {
   t.assert(m1.get('number') === 1)
   t.assert(m1.get('string') === 'hello')
 
+  /** @type {Y.Map<{ object: { x: number; }; boolean: boolean; }>} */
   const m2 = new Y.Map([
     ['object', { x: 1 }],
     ['boolean', true]
   ])
   map0.set('m2', m2)
-  t.assert(m2.get('object').x === 1)
+  t.assert(m2.get('object')?.x === 1)
   t.assert(m2.get('boolean') === true)
 
+  /** @type {Y.Map<any>} */
   const m3 = new Y.Map([...m1, ...m2])
   map0.set('m3', m3)
   t.assert(m3.get('number') === 1)
@@ -281,7 +283,7 @@ export const testGetAndSetAndDeleteOfMapPropertyWithThreeConflicts = tc => {
  */
 export const testObserveDeepProperties = tc => {
   const { testConnector, users, map1, map2, map3 } = init(tc, { users: 4 })
-  const _map1 = map1.set('map', new Y.Map())
+  const _map1 = map1.set('map', /** @type {Y.Map<{ deepmap: Y.Map<any> }>} */ (new Y.Map()))
   let calls = 0
   let dmapid
   map1.observeDeep(events => {
@@ -306,10 +308,10 @@ export const testObserveDeepProperties = tc => {
   const dmap2 = _map2.get('deepmap')
   const dmap3 = _map3.get('deepmap')
   t.assert(calls > 0)
-  t.assert(compareIDs(dmap1._item.id, dmap2._item.id))
-  t.assert(compareIDs(dmap1._item.id, dmap3._item.id))
+  t.assert(compareIDs(dmap1?._item?.id || null, dmap2._item.id))
+  t.assert(compareIDs(dmap1?._item?.id || null, dmap3._item.id))
   // @ts-ignore we want the possibility of dmapid being undefined
-  t.assert(compareIDs(dmap1._item.id, dmapid))
+  t.assert(compareIDs(dmap1?._item?.id || null, dmapid))
   compare(users)
 }
 


### PR DESCRIPTION
Resolves #499. 

This type-only PR modifies the semantics of `Y.Map`'s generic type parameter, to make it describe the exact shape of the map rather than the type of its values. This parameter is then used to improve the argument and return types of public-facing `Map` methods, where it makes sense to do so.

## Design Goals

### Model schemas

This change enables the use of the type parameter to validate the types of maps which represent "models", which may have values of different types and only certain valid keys. Currently, users trying to use YJS as a frontend database for TypeScript will frequently run into this issue:

```ts
type User = {
  name: string;
  age?: number;
};

const map = doc.getMap<User>();

// ERROR: Argument of type 'string' is not assignable to parameter of type 'User'
user.set("name", "Tina Belcher")

// userAge has the incorrect type `User | undefined`
const userAge = map.get("age")
```

As someone who writes a lot of TS, these issues significantly hamper adoption in complex software.

### Helping maintain data consistency

Even though YJS has a distributed data model, many designs will limit contributions to a particular YJS document to different users of the same software. By presenting type errors when attempting to set a field to a type that does not match the developer's specified schema, we can help developers to protect document consistency and prevent potentially tricky to debug document poisoning.

### Accurately reflect YJS's API

While users of YJS (or at least this one) want types to help us avoid accidentally corrupting our document schema, it's also important to recognize that YJS's low-level API does not include the concept of a schema. Therefore, there must be a way for users to bypass this schema validation, for instance to migrate documents from one version of software to another, or to opt out of typed schemas completely.

Additionally, the design of YJS's API precludes the ability to guarantee that fields are not undefined. Because of this, we should still include `undefined` as a possible return value of `map.get`, even when the map is bound to a schema type.

Finally, YJS only allows certain types of values to be included in a `Y.Map`. The type definitions should prevent users from accidentally trying to store invalid, unserializable values in a `Y.Map` under any circumstance.

### Supporting existing use cases

It's also important to maintain the ability to define types similar to what can be used today. While there does not appear to be a way to make this change non-breaking without significantly increasing code complexity, the migration path for any users who are happily using the existing types is quite simple:

```ts

const map = doc.getMap<number>();
// becomes...
const map = doc.getMap<Record<string, number>>();
```

While this migration step is unfortunate, my opinion is that the post-migration types will more clearly communicate to TS developers the shape of the data contained in the map.

## Testing

`npm run lint` passes with no type errors. Unfortunately I've had to include some `any` types in the internal implementations to get there due to limitations of JSDoc types and to avoid getting into logic changes, but I've kept these as limited in scope as I can. Of note, these changes to `Y.Map`'s type interface caught a couple of issues in test cases that easily could have led to runtime errors outside of a test case.

I've also included a typescript file I used to validate the public type interface, which also helps demonstrates the semantics under various cases. This file is not required for the change to work, and can be removed from the PR if you don't think it will be useful in the future.

I am probably not the most experienced YJS user out there, so I would appreciate anyone willing to volunteer to help test these types under more complex scenarios :slightly_smiling_face: 