### PR TITLE
Allow falsy attribute values

### DIFF
--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -227,7 +227,7 @@ const insertAttributes = (transaction, parent, currPos, attributes) => {
   // insert format-start items
   for (const key in attributes) {
     const val = attributes[key]
-    const currentVal = currPos.currentAttributes.get(key) || null
+    const currentVal = currPos.currentAttributes.get(key) ?? null
     if (!equalAttrs(currentVal, val)) {
       // save negated attribute (set null if currentVal undefined)
       negatedAttributes.set(key, currentVal)


### PR DESCRIPTION
Hi Yjs-folks!

First of all thanks for this awesome piece of software :heart: I'm currently working on the integration of a [`slate`](https://github.com/ianstormtaylor/slate)-based editor into my app, using [`slate-yjs`](https://github.com/BitPhinix/slate-yjs) to allow collaborative editing. During testing of the editor I came across an issue, where using falsy attribute values lead to problems within slate-yjs. I found the reason of the problems within slate-yjs however to be caused by this [LOC within yjs](https://github.com/yjs/yjs/blob/90675be3ab74df86cfd2e15d49f1f7efb00743f2/src/types/YText.js#L230). 

To better understand this problem, please picture the following scenario:
I got a document with a YXmlText that looks like the following after calling `.toJSON()`.
```text
<fontface><fontsize>Some Text</fontsize></fontface>
```
The YXmlText therefore has the attributes `fontface` and `fontsize`, however in this case both are set to an empty string (`''`), resulting in the above representation. When I insert any character within that text, passing the same attributes (`{fontface: '', fontsize: ''}`), `YText#insertAttributes` will drop the falsy attributes, resulting in different attributes for the inserted character, despite me passing in the same attributes as the surrounding text. This then leads to slate-yjs having trouble mapping a slate document node to a YXmlText node, because for one document node there suddenly are multpile YXmlText nodes with differing attributes.

This MR fixes this issue, by replacing the logical or operation in the above linked LOC with the nullish coalescing operator. However, I'm unsure if your implementation using the logical or operation is by design. Maybe this operation was chosen to minimize YDoc storage consumption?