### PR TITLE
update search marker count in INTERNALS.md

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -88,7 +88,7 @@ When a local insert happens, Yjs needs to map the insert position in the
 document (eg position 1000) to an ID. With just the linked list, this would
 require a slow O(n) linear scan of the list. But when editing a document, most
 inserts are either at the same position as the last insert, or nearby. To
-improve performance, Yjs stores a cache of the 10 most recently looked up
+improve performance, Yjs stores a cache of the 80 most recently looked up
 insert positions in the document. This is consulted and updated when a position
 is looked up to improve performance in the average case. The cache is updated
 using a heuristic that is still changing (currently, it is updated when a new


### PR DESCRIPTION
The `markPosition()` and `findMarker()` functions in `src/types/AbstractType.js` both handle **search marker** with an upper bound `maxSearchMarker`, which is defined as `const maxSearchMarker = 80`. but according to **INTERNALS.md**, it says `Yjs stores a cache of the 10 most recently looked up insert positions in the document.` Are they same concept? 
Give a try to update the value in **INTERNALS.md** if they are.