### PR TITLE
Add y-op-sqlite to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ Like y-indexeddb, but with sub-documents support and fully TypeScript.
   <dd>
 A database and connection provider for Yjs based on Firestore.
   </dd>
+  <dt><a href="https://github.com/malte-j/y-op-sqlite">y-op-sqlite</a></dt>
+  <dd>
+Persist YJS updates in your React Native app using <a href="https://github.com/OP-Engineering/op-sqlite">op-sqlite</a>, the fastest SQLite library for React Native. 
+  </dd>
 </dl>
 
 # Ports


### PR DESCRIPTION
I needed a way to persist YJS documents in my React Native app and was already using OP-SQLite, so I built a persistence provider called [y-op-sqlite](https://github.com/malte-j/y-op-sqlite) to store updates in the SQLite database. 

I'm happy about every bit of feedback!

<sub><a href="https://huly.app/guest/yjs?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjMxMDBjZjAyYzdiMjYwNDYzMTA4MTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.uy9o28z4fZ-Olcy6VaTTT-gaT73n60ExFgLikw_h7Ac">Huly&reg;: <b>YJS-815</b></a></sub>