### PR TITLE
missing state vector should be usable for update encoding

### DIFF
--- a/src/utils/encoding.js
+++ b/src/utils/encoding.js
@@ -265,7 +265,10 @@ const integrateStructs = (transaction, store, clientsStructRefs) => {
    */
   const updateMissingSv = (client, clock) => {
     const mclock = missingSV.get(client)
-    if (mclock == null || mclock > clock) {
+    if (mclock === undefined) {
+      // we never seen that client before
+      missingSV.set(client, 0)
+    } else if (mclock > clock) {
       missingSV.set(client, clock)
     }
   }


### PR DESCRIPTION
The following test confirms an edge case when missing state vector is not correctly computed.

When we get an out-of-order update for a client, that has never been seen before, a computed missing state vector starts from that update start clock instead of 0.

Second commit contains proposed solution.

<sub><a href="https://huly.app/guest/yjs?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjMzMmVkYTAyYzdiMjYwNDYzMmRiNmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.tCvMYXI_VVOmBqlgObtIjMlAXkYN97HEbppHz9EgQMQ">Huly&reg;: <b>YJS-816</b></a></sub>