### PR TITLE
Fix y-websocket `server.cjs` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ npm i yjs y-websocket
 Start the y-websocket server:
 
 ```sh
-PORT=1234 node ./node_modules/y-websocket/bin/server.js
+PORT=1234 node ./node_modules/y-websocket/bin/server.cjs
 ```
 
 ### Example: Observe types


### PR DESCRIPTION
The commmit https://github.com/yjs/y-websocket/commit/c3d14cf07d8628431a7480213131ce58cad9adc9 renamed `server.js` to `server.cjs`; mirror that change here.

<sub><a href="https://huly.app/guest/yjs?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjNjYWMyODYzNGI1M2M3ZjEyMGMxNjAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.6oFZjDnwO2ulc1DbxefZQIaYXLUOf1lzbQC5G0nh-lc">Huly&reg;: <b>YJS-818</b></a></sub>