### PR TITLE
Add y-postgresql to provider list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ A database and connection provider for Yjs based on Firestore.
   <dd>
 Persist YJS updates in your React Native app using <a href="https://github.com/OP-Engineering/op-sqlite">op-sqlite</a>, the fastest SQLite library for React Native. 
   </dd>
+  <dt><a href="https://github.com/MaxNoetzold/y-postgresql">y-postgresql</a></dt>
+  <dd>
+Provides persistent storage for a web server using PostgreSQL and is easily compatible with y-websocket.
+  </dd>
 </dl>
 
 # Ports

--- a/README.md
+++ b/README.md
@@ -270,11 +270,14 @@ A database and connection provider for Yjs based on Firestore.
   </dd>
   <dt><a href="https://github.com/malte-j/y-op-sqlite">y-op-sqlite</a></dt>
   <dd>
-Persist YJS updates in your React Native app using <a href="https://github.com/OP-Engineering/op-sqlite">op-sqlite</a>, the fastest SQLite library for React Native. 
+  Persist YJS updates in your React Native app using
+   <a href="https://github.com/OP-Engineering/op-sqlite">op-sqlite</a>
+  , the fastest SQLite library for React Native.  
   </dd>
   <dt><a href="https://github.com/MaxNoetzold/y-postgresql">y-postgresql</a></dt>
   <dd>
-Provides persistent storage for a web server using PostgreSQL and is easily compatible with y-websocket.
+  Provides persistent storage for a web server using PostgreSQL and
+  is easily compatible with y-websocket.  
   </dd>
 </dl>
 


### PR DESCRIPTION
Add my new [PostgreSQL Provider](https://github.com/MaxNoetzold/y-postgresql) to the provider list in the README file so users can find it if they need one.

<sub><a href="https://huly.app/guest/yjs?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjRjYTJiYzEwYjdiODJiMTQ1MjY1NjEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.99lSJbaUutmD7-4OnNpQLRa23abstvwYCbQu2lbVpEo">Huly&reg;: <b>YJS-822</b></a></sub>