### PR TITLE
Export mergeDeleteSets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ export {
   UpdateDecoderV1,
   UpdateDecoderV2,
   equalDeleteSets,
+  mergeDeleteSets,
   snapshotContainsUpdate
 } from './internals.js'
 


### PR DESCRIPTION
Useful for comparing snapshots.

I tried reimplementing it in my own code but it depends on the `DeleteSet` class, which is also not exported.

<sub><a href="https://huly.app/guest/yjs?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjYxOWZmNjhmODE1YzM1ZjQ0ZDdhMDAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6InctZ2l0aHViZG1vbmFkLXlqcy02NjBkNTc3Mi03MGYwNmEwYTIyLWQyOGNmNSIsInByb2R1Y3RJZCI6IiJ9.BchwzO54K5QG9nzZJxSnFiQQn2D2EuEU2cHH2Ou21LI">Huly&reg;: <b>YJS-824</b></a></sub>