### PR TITLE
Include `Item.redone` in binary encoding

### DIFF
--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -643,7 +643,7 @@ export const typeListInsertGenericsAfter = (transaction, parent, referenceItem, 
   let jsonContent = []
   const packJsonContent = () => {
     if (jsonContent.length > 0) {
-      left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentAny(jsonContent))
+      left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, new ContentAny(jsonContent))
       left.integrate(transaction, 0)
       jsonContent = []
     }
@@ -665,16 +665,16 @@ export const typeListInsertGenericsAfter = (transaction, parent, referenceItem, 
           switch (c.constructor) {
             case Uint8Array:
             case ArrayBuffer:
-              left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentBinary(new Uint8Array(/** @type {Uint8Array} */ (c))))
+              left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, new ContentBinary(new Uint8Array(/** @type {Uint8Array} */ (c))))
               left.integrate(transaction, 0)
               break
             case Doc:
-              left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentDoc(/** @type {Doc} */ (c)))
+              left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, new ContentDoc(/** @type {Doc} */ (c)))
               left.integrate(transaction, 0)
               break
             default:
               if (c instanceof AbstractType) {
-                left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentType(c))
+                left = new Item(createID(ownClientId, getState(store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, new ContentType(c))
                 left.integrate(transaction, 0)
               } else {
                 throw new Error('Unexpected content type in insert operation')
@@ -862,7 +862,7 @@ export const typeMapSet = (transaction, parent, key, value) => {
         }
     }
   }
-  new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, null, null, parent, key, content).integrate(transaction, 0)
+  new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, null, null, parent, key, null, content).integrate(transaction, 0)
 }
 
 /**

--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -166,7 +166,7 @@ const insertNegatedAttributes = (transaction, parent, currPos, negatedAttributes
   negatedAttributes.forEach((val, key) => {
     const left = currPos.left
     const right = currPos.right
-    const nextFormat = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentFormat(key, val))
+    const nextFormat = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, new ContentFormat(key, val))
     nextFormat.integrate(transaction, 0)
     currPos.right = nextFormat
     currPos.forward()
@@ -232,7 +232,7 @@ const insertAttributes = (transaction, parent, currPos, attributes) => {
       // save negated attribute (set null if currentVal undefined)
       negatedAttributes.set(key, currentVal)
       const { left, right } = currPos
-      currPos.right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, new ContentFormat(key, val))
+      currPos.right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, new ContentFormat(key, val))
       currPos.right.integrate(transaction, 0)
       currPos.forward()
     }
@@ -266,7 +266,7 @@ const insertText = (transaction, parent, currPos, text, attributes) => {
   if (parent._searchMarker) {
     updateMarkerChanges(parent._searchMarker, currPos.index, content.getLength())
   }
-  right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, content)
+  right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), left, left && left.lastId, right, right && right.id, parent, null, null, content)
   right.integrate(transaction, 0)
   currPos.right = right
   currPos.index = index
@@ -342,7 +342,7 @@ const formatText = (transaction, parent, currPos, length, attributes) => {
     for (; length > 0; length--) {
       newlines += '\n'
     }
-    currPos.right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), currPos.left, currPos.left && currPos.left.lastId, currPos.right, currPos.right && currPos.right.id, parent, null, new ContentString(newlines))
+    currPos.right = new Item(createID(ownClientId, getState(doc.store, ownClientId)), currPos.left, currPos.left && currPos.left.lastId, currPos.right, currPos.right && currPos.right.id, parent, null, null, new ContentString(newlines))
     currPos.right.integrate(transaction, 0)
     currPos.forward()
   }

--- a/src/utils/UpdateDecoder.js
+++ b/src/utils/UpdateDecoder.js
@@ -47,6 +47,13 @@ export class UpdateDecoderV1 extends DSDecoderV1 {
   }
 
   /**
+   * @return {ID}
+   */
+  readRedone () {
+    return createID(decoding.readVarUint(this.restDecoder), decoding.readVarUint(this.restDecoder))
+  }
+
+  /**
    * Read the next client id.
    * Use this in favor of readID whenever possible to reduce the number of objects created.
    */
@@ -174,6 +181,7 @@ export class UpdateDecoderV2 extends DSDecoderV2 {
     this.clientDecoder = new decoding.UintOptRleDecoder(decoding.readVarUint8Array(decoder))
     this.leftClockDecoder = new decoding.IntDiffOptRleDecoder(decoding.readVarUint8Array(decoder))
     this.rightClockDecoder = new decoding.IntDiffOptRleDecoder(decoding.readVarUint8Array(decoder))
+    this.redoneClockDecoder = new decoding.IntDiffOptRleDecoder(decoding.readVarUint8Array(decoder))
     this.infoDecoder = new decoding.RleDecoder(decoding.readVarUint8Array(decoder), decoding.readUint8)
     this.stringDecoder = new decoding.StringDecoder(decoding.readVarUint8Array(decoder))
     this.parentInfoDecoder = new decoding.RleDecoder(decoding.readVarUint8Array(decoder), decoding.readUint8)
@@ -193,6 +201,13 @@ export class UpdateDecoderV2 extends DSDecoderV2 {
    */
   readRightID () {
     return new ID(this.clientDecoder.read(), this.rightClockDecoder.read())
+  }
+
+  /**
+   * @return {ID}
+   */
+  readRedone () {
+    return new ID(this.clientDecoder.read(), this.redoneClockDecoder.read())
   }
 
   /**

--- a/src/utils/UpdateEncoder.js
+++ b/src/utils/UpdateEncoder.js
@@ -51,6 +51,14 @@ export class UpdateEncoderV1 extends DSEncoderV1 {
   }
 
   /**
+   * @param {ID} id
+   */
+  writeRedone (id) {
+    encoding.writeVarUint(this.restEncoder, id.client)
+    encoding.writeVarUint(this.restEncoder, id.clock)
+  }
+
+  /**
    * Use writeClient and writeClock instead of writeID if possible.
    * @param {number} client
    */
@@ -177,6 +185,7 @@ export class UpdateEncoderV2 extends DSEncoderV2 {
     this.clientEncoder = new encoding.UintOptRleEncoder()
     this.leftClockEncoder = new encoding.IntDiffOptRleEncoder()
     this.rightClockEncoder = new encoding.IntDiffOptRleEncoder()
+    this.redoneClockEncoder = new encoding.IntDiffOptRleEncoder()
     this.infoEncoder = new encoding.RleEncoder(encoding.writeUint8)
     this.stringEncoder = new encoding.StringEncoder()
     this.parentInfoEncoder = new encoding.RleEncoder(encoding.writeUint8)
@@ -191,6 +200,7 @@ export class UpdateEncoderV2 extends DSEncoderV2 {
     encoding.writeVarUint8Array(encoder, this.clientEncoder.toUint8Array())
     encoding.writeVarUint8Array(encoder, this.leftClockEncoder.toUint8Array())
     encoding.writeVarUint8Array(encoder, this.rightClockEncoder.toUint8Array())
+    encoding.writeVarUint8Array(encoder, this.redoneClockEncoder.toUint8Array())
     encoding.writeVarUint8Array(encoder, encoding.toUint8Array(this.infoEncoder))
     encoding.writeVarUint8Array(encoder, this.stringEncoder.toUint8Array())
     encoding.writeVarUint8Array(encoder, encoding.toUint8Array(this.parentInfoEncoder))
@@ -215,6 +225,14 @@ export class UpdateEncoderV2 extends DSEncoderV2 {
   writeRightID (id) {
     this.clientEncoder.write(id.client)
     this.rightClockEncoder.write(id.clock)
+  }
+
+  /**
+   * @param {ID} id
+   */
+  writeRedone (id) {
+    this.clientEncoder.write(id.client)
+    this.redoneClockEncoder.write(id.clock)
   }
 
   /**

--- a/src/utils/encoding.js
+++ b/src/utils/encoding.js
@@ -127,7 +127,7 @@ export const readClientsStructRefs = (decoder, doc) => {
     clientRefs.set(client, { i: 0, refs })
     for (let i = 0; i < numberOfStructs; i++) {
       const info = decoder.readInfo()
-      switch (binary.BITS5 & info) {
+      switch (binary.BITS4 & info) {
         case 0: { // GC
           const len = decoder.readLen()
           refs[i] = new GC(createID(client, clock), len)
@@ -160,6 +160,7 @@ export const readClientsStructRefs = (decoder, doc) => {
             (info & binary.BIT7) === binary.BIT7 ? decoder.readRightID() : null, // right origin
             cantCopyParentInfo ? (decoder.readParentInfo() ? doc.get(decoder.readString()) : decoder.readLeftID()) : null, // parent
             cantCopyParentInfo && (info & binary.BIT6) === binary.BIT6 ? decoder.readString() : null, // parentSub
+            (info & binary.BIT5) === binary.BIT5 ? decoder.readRedone() : null, // redone
             readItemContent(decoder, info) // item content
           )
           /* A non-optimized implementation of the above algorithm:
@@ -184,6 +185,7 @@ export const readClientsStructRefs = (decoder, doc) => {
             rightOrigin, // right origin
             cantCopyParentInfo && !hasParentYKey ? decoder.readLeftID() : (parentYKey !== null ? doc.get(parentYKey) : null), // parent
             cantCopyParentInfo && (info & binary.BIT6) === binary.BIT6 ? decoder.readString() : null, // parentSub
+            (info & binary.BIT5) === binary.BIT5 ? decoder.readRedone() : null, // redone
             readItemContent(decoder, info) // item content
           )
           */

--- a/src/utils/updates.js
+++ b/src/utils/updates.js
@@ -53,7 +53,7 @@ function * lazyStructReaderGenerator (decoder) {
         const len = decoding.readVarUint(decoder.restDecoder)
         yield new Skip(createID(client, clock), len)
         clock += len
-      } else if ((binary.BITS5 & info) !== 0) {
+      } else if ((binary.BITS4 & info) !== 0) {
         const cantCopyParentInfo = (info & (binary.BIT7 | binary.BIT8)) === 0
         // If parent = null and neither left nor right are defined, then we know that `parent` is child of `y`
         // and we read the next string as parentYKey.
@@ -68,6 +68,7 @@ function * lazyStructReaderGenerator (decoder) {
           // @ts-ignore Force writing a string here.
           cantCopyParentInfo ? (decoder.readParentInfo() ? decoder.readString() : decoder.readLeftID()) : null, // parent
           cantCopyParentInfo && (info & binary.BIT6) === binary.BIT6 ? decoder.readString() : null, // parentSub
+          (info & binary.BIT5) === binary.BIT5 ? decoder.readRedone() : null, // redone
           readItemContent(decoder, info) // item content
         )
         yield struct
@@ -316,6 +317,7 @@ const sliceStruct = (left, diff) => {
       leftItem.rightOrigin,
       leftItem.parent,
       leftItem.parentSub,
+      null,
       leftItem.content.splice(diff)
     )
   }

--- a/tests/relativePositions.tests.js
+++ b/tests/relativePositions.tests.js
@@ -120,6 +120,6 @@ export const testRelativePositionWithUndo = tc => {
   t.assert(Y.createAbsolutePositionFromRelativePosition(rpos, ydoc, false)?.index === 6)
   const ydocClone = new Y.Doc()
   Y.applyUpdate(ydocClone, Y.encodeStateAsUpdate(ydoc))
-  t.assert(Y.createAbsolutePositionFromRelativePosition(rpos, ydocClone)?.index === 6)
+  t.assert(Y.createAbsolutePositionFromRelativePosition(rpos, ydocClone)?.index === 1)
   t.assert(Y.createAbsolutePositionFromRelativePosition(rpos, ydocClone, false)?.index === 6)
 }

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -2079,7 +2079,7 @@ export const testBestCase = _tc => {
       /**
        * @type {Y.Item}
        */
-      const n = new Y.Item(Y.createID(0, 0), null, null, null, null, null, null, c)
+      const n = new Y.Item(Y.createID(0, 0), null, null, null, null, null, null, null, c)
       // items.push(n)
       items[i] = n
       n.right = prevItem


### PR DESCRIPTION
**Related issue:**
- https://github.com/yjs/yjs/issues/638

**Description:**
I'm looking to build a commenting solution using relative positions. I ran into the same issue described in #638, but in my case I would like all clients to be able to "follow the redo-path" as described by @dmonad [here](https://github.com/yjs/yjs/issues/638#issuecomment-2080220529), and looked into persisting into persisting `Item.redone` in the binary encoding of the document. 

**Implementation:**
In the `info` byte, I took `BIT5` away from `contentRefs` and used it to signal the presence of `redone`. We were using 5 bits to store the content type, but 4 bits is sufficient for the 10 possible options.

I updated the V1 and V2 Encoders and Decoders to write the `redone` ID if it exists, based on the implementations for `leftID` and `rightID`.

**Testing:**
I updated the second-last assertion in `testRelativePositionWithUndo`, which was testing for the opposite behaviour from what I was looking for. Now the test shows that both the local client, who originated the Undo operation, and the remote client who received it, both have the option whether or not to follow the redone path when resolving a relative position.

Please let me know if you have any feedback @dmonad 🙏 I'm not sure if this PR goes contrary to an intentional design decision!