### PR TITLE
Fix `createAbsolutePositionFromRelativePosition` with `followUndoneDeletions=false`

### DIFF
--- a/src/utils/RelativePosition.js
+++ b/src/utils/RelativePosition.js
@@ -286,7 +286,14 @@ export const createAbsolutePositionFromRelativePosition = (rpos, doc, followUndo
     if (getState(store, rightID.client) <= rightID.clock) {
       return null
     }
-    const res = followUndoneDeletions ? followRedone(store, rightID) : { item: getItem(store, rightID), diff: 0 }
+    /** @type {ReturnType<typeof followRedone>} */
+    let res;
+    if (followUndoneDeletions) {
+      res = followRedone(store, rightID)
+    } else {
+      const item = getItem(store, rightID)
+      res = { item, diff: rightID.clock - item.id.clock }
+    }
     const right = res.item
     if (!(right instanceof Item)) {
       return null

--- a/tests/relativePositions.tests.js
+++ b/tests/relativePositions.tests.js
@@ -123,3 +123,17 @@ export const testRelativePositionWithUndo = tc => {
   t.assert(Y.createAbsolutePositionFromRelativePosition(rpos, ydocClone)?.index === 6)
   t.assert(Y.createAbsolutePositionFromRelativePosition(rpos, ydocClone, false)?.index === 6)
 }
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionWithoutUndo = tc => {
+  const ydoc = new Y.Doc()
+  const ytext = ydoc.getText()
+  ytext.insert(0, 'abcde')
+  const rpos = Y.createRelativePositionFromTypeIndex(ytext, 2)
+  const posWithFollow = Y.createAbsolutePositionFromRelativePosition(rpos, ydoc, true)
+  t.assert(posWithFollow?.index === 2)
+  const posWithoutFollow = Y.createAbsolutePositionFromRelativePosition(rpos, ydoc, false)
+  t.assert(posWithoutFollow?.index === 2)
+}


### PR DESCRIPTION
Fixes #657

When not following undone deletions, instead of assuming that the `diff` property is 0, I added the corresponding computation done by `followRedone`.

Mind that **I don't really know what I'm doing**, but it seems to work for my project and both tests pass.