### PR TITLE
Add missing functions and remove erroneus function from API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ necessary.
   </p>
   <pre>const yarray = new Y.Array()</pre>
   <dl>
+    <b><code>Y.Array.from(Array&lt;object|boolean|Array|string|number|null|Uint8Array|Y.Type&gt;): Y.Array</code></b>
+    <dd>An alternative factory function to create a Y.Array based on existing content.</dd>
     <b><code>parent:Y.AbstractType|null</code></b>
     <dd></dd>
     <b><code>insert(index:number, content:Array&lt;object|boolean|Array|string|number|null|Uint8Array|Y.Type&gt;)</code></b>
@@ -441,6 +443,8 @@ forEach(function(value:object|boolean|Array|string|number|null|Uint8Array|Y.Type
     <dd></dd>
     <b><code>map(function(T, number, YArray):M):Array&lt;M&gt;</code></b>
     <dd></dd>
+    <b><code>clone(): Y.Array</code></b>
+    <dd>Clone all values into a fresh Y.Array instance. The returned type can be included into the Yjs document.</dd>
     <b><code>toArray():Array&lt;object|boolean|Array|string|number|null|Uint8Array|Y.Type&gt;</code></b>
     <dd>Copies the content of this YArray to a new Array.</dd>
     <b><code>toJSON():Array&lt;Object|boolean|Array|string|number|null&gt;</code></b>

--- a/README.md
+++ b/README.md
@@ -501,8 +501,6 @@ or any of its children.
     <dd></dd>
     <b><code>has(key:string):boolean</code></b>
     <dd></dd>
-    <b><code>get(index:number)</code></b>
-    <dd></dd>
     <b><code>clear()</code></b>
     <dd>Removes all elements from this YMap.</dd>
     <b><code>clone():Y.Map</code></b>


### PR DESCRIPTION
Documented `Y.Array.from()` and `yarray.clone()` that exist in the implementation.

There is no `ymap.get(index:number)`