### PR TITLE
docs: remove `@toeverything/y-indexeddb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,11 +281,6 @@ network provider.
 Adds persistent storage to a server with MongoDB. Can be used with the
 y-websocket provider.
   </dd>
-  <dt><a href="https://github.com/toeverything/AFFiNE/tree/master/packages/y-indexeddb">
-@toeverything/y-indexeddb</a></dt>
-  <dd>
-Like y-indexeddb, but with sub-documents support and fully TypeScript.
-  </dd>
   <dt><a href="https://github.com/podraven/y-fire">y-fire</a></dt>
   <dd>
 A database and connection provider for Yjs based on Firestore.


### PR DESCRIPTION
Upstream has removed this package in their repo, https://github.com/toeverything/AFFiNE/pull/6728