### PR TITLE
Add PSPDFKit binding to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ are implemented in separate modules.
 | React | | [react-yjs](https://github.com/nikgraf/react-yjs) | [demo](https://react-yjs-example.vercel.app/) |
 | React / Vue / Svelte / MobX | | [SyncedStore](https://syncedstore.org) | [demo](https://syncedstore.org/docs/react) |
 | [mobx-keystone](https://mobx-keystone.js.org/) |  | [mobx-keystone-yjs](https://github.com/xaviergonz/mobx-keystone/tree/master/packages/mobx-keystone-yjs) | [demo](https://mobx-keystone.js.org/examples/yjs-binding) |
+| [PSPDFKit](https://www.nutrient.io/) |  | [yjs-pspdfkit](https://github.com/hoangqwe159/yjs-pspdfkit) | [demo](https://github.com/hoangqwe159/yjs-pspdfkit) |
 
 ### Providers
 


### PR DESCRIPTION
This pull request updates the README.md by adding [yjs-pspdfkit](https://github.com/hoangqwe159/yjs-pspdfkit) to the list of bindings.