### PR TITLE
fix: allow numbers in attribute values

### DIFF
--- a/src/types/YXmlElement.js
+++ b/src/types/YXmlElement.js
@@ -25,7 +25,7 @@ import {
  * * An YXmlElement has attributes (key value pairs)
  * * An YXmlElement has childElements that must inherit from YXmlElement
  *
- * @template {{ [key: string]: ValueTypes }} [KV={ [key: string]: string }]
+ * @template {{ [key: string]: ValueTypes }} [KV={ [key: string]: string | number }]
  */
 export class YXmlElement extends YXmlFragment {
   constructor (nodeName = 'UNDEFINED') {
@@ -94,7 +94,7 @@ export class YXmlElement extends YXmlFragment {
     const el = new YXmlElement(this.nodeName)
     const attrs = this.getAttributes()
     object.forEach(attrs, (value, key) => {
-      if (typeof value === 'string') {
+      if (typeof value === 'string' || typeof value === 'number') {
         el.setAttribute(key, value)
       }
     })
@@ -226,8 +226,8 @@ export class YXmlElement extends YXmlFragment {
     const attrs = this.getAttributes()
     for (const key in attrs) {
       const value = attrs[key]
-      if (typeof value === 'string') {
-        dom.setAttribute(key, value)
+      if (typeof value === 'string' || typeof value === 'number') {
+        dom.setAttribute(key, String(value))
       }
     }
     typeListForEach(this, yxml => {

--- a/tests/y-xml.tests.js
+++ b/tests/y-xml.tests.js
@@ -198,6 +198,25 @@ export const testClone = _tc => {
 /**
  * @param {t.TestCase} _tc
  */
+export const testCloneElementAttributes = _tc => {
+  const ydoc = new Y.Doc()
+  const yxml = ydoc.getXmlFragment()
+  const first = new Y.XmlText('text')
+  const second = new Y.XmlElement('p')
+  second.setAttribute('answer', 42)
+  const third = new Y.XmlElement('p')
+  third.setAttribute('question', 'unknown')
+  yxml.push([first, second, third])
+  t.compareArrays(yxml.toArray(), [first, second, third])
+  const cloneYxml = yxml.clone()
+  ydoc.getArray('copyarr').insert(0, [cloneYxml])
+  t.assert(cloneYxml.length === 3)
+  t.compare(cloneYxml.toJSON(), yxml.toJSON())
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
 export const testFormattingBug = _tc => {
   const ydoc = new Y.Doc()
   const yxml = /** @type {Y.XmlText} */ (ydoc.get('', Y.XmlText))


### PR DESCRIPTION
Changes YXMLElement to allow numbers in attribute values

This seems like a common use case when working with YJS and Prosemirror/TipTap schemas, since anything from list values, indent values, to heading levels will contain numeric values instead of strings when converting between YJS and Prosemirror.

fixes #680 