### PR TITLE
README: Remove a duplicate SageMaker mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Showcase](https://yjs-diagram.synergy.codes/).
   Learning Models
 * [linear](https://linear.app) Streamline issues, projects, and product roadmaps.
 * [btw](https://www.btw.so) - Personal website builder
-* [AWS SageMaker](https://aws.amazon.com/sagemaker/) - Machine Learning Service
 * [Arkiter](https://www.arkiter.com/) - Live interview software
 * [Appflowy](https://www.appflowy.io/) - They use Yrs
 * [Multi.app](https://multi.app) - Multiplayer app sharing: Point, draw and edit


### PR DESCRIPTION
AWS SageMaker was mentioned twice.  Remove one of the mentions.