### PR TITLE
expose missing parts that allow to decode binary messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,9 @@ export {
   UpdateDecoderV2,
   equalDeleteSets,
   mergeDeleteSets,
-  snapshotContainsUpdate
+  snapshotContainsUpdate,
+  LazyStructReader,
+  readDeleteSet
 } from './internals.js'
 
 const glo = /** @type {any} */ (typeof globalThis !== 'undefined'


### PR DESCRIPTION
There are not exposed parts that block decoding binary messages from other parts of application.
With those two exports it's possible with following code

```js
import * as Y from "yjs"
import * as decoding from "lib0/decoding"
const doc = Y.Doc()
doc.on("update", (e) => {
	const structs = []
	const updateDecoder = new Y.UpdateDecoderV1(decoding.createDecoder(e))
	const lazyDecoder = new Y.LazyDecoder(updateDecoder)
	for (let curr = lazyDecoder.curr; curr !== null; curr = lazyDecoder.next()) {
		structs.push(curr)
	}
	const deleteSet = Y.readDeleteSet(updateDecoder)
	console.log(structs, deleteSet)
})
```