### PR TITLE
README: Update outdated y-sweet debugger hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ A database and connection provider for Yjs based on Firestore.
 
 ### Tooling
 
-* [y-sweet debugger](https://docs.jamsocket.com/y-sweet/advanced/debugger)
+* [y-sweet debugger](https://y-sweet.cloud/advanced/debugger)
 * [liveblocks devtools](https://liveblocks.io/devtools)
 * [Yjs inspector](https://inspector.yjs.dev)
 


### PR DESCRIPTION
Hyperlink to y-sweet debugger "https://docs.jamsocket.com/y-sweet/advanced/debugger" is outdated. (404 error)
The docs seems to have been moved to "https://y-sweet.cloud/advanced/debugger".