### PR TITLE
Add doc.beginTransaction() → callback, as an alternative to doc.transact()

### DIFF
--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -11,6 +11,7 @@ import {
   YXmlElement,
   YXmlFragment,
   transact,
+  beginTransaction,
   applyUpdate,
   ContentDoc, Item, Transaction, YEvent, // eslint-disable-line
   encodeStateAsUpdate
@@ -190,6 +191,22 @@ export class Doc extends ObservableV2 {
    */
   transact (f, origin = null) {
     return transact(this, f, origin)
+  }
+
+  /**
+   * Begins a transaction and returns a callback that finishes it.
+   * This is equivalent to `y.transact(() => { ... })` but
+   * allows you to perform transactions without passing a callback.
+   * You must call the returned function to finish the transaction.
+   *
+   * @param {any} [origin=null]
+   * @return {[Transaction, function():void]}
+   *
+   * @public
+   * @function
+   */
+  beginTransaction (origin = null) {
+    return beginTransaction(this, origin)
   }
 
   /**

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -1,16 +1,16 @@
 import {
-  getState,
-  writeStructsFromTransaction,
-  writeIdSet,
-  getStateVector,
-  findIndexSS,
-  callEventHandlerListeners,
-  createIdSet,
-  Item,
-  generateNewClientId,
-  createID,
-  cleanupYTextAfterTransaction,
-  IdSet, UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
+    getState,
+    writeStructsFromTransaction,
+    writeIdSet,
+    getStateVector,
+    findIndexSS,
+    callEventHandlerListeners,
+    createIdSet,
+    Item,
+    generateNewClientId,
+    createID,
+    cleanupYTextAfterTransaction,
+    IdSet, UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
 } from '../internals.js'
 
 import * as error from 'lib0/error'
@@ -18,7 +18,7 @@ import * as map from 'lib0/map'
 import * as math from 'lib0/math'
 import * as set from 'lib0/set'
 import * as logging from 'lib0/logging'
-import { callAll } from 'lib0/function'
+import {callAll} from 'lib0/function'
 
 /**
  * A transaction is created for every change on the Yjs model. It is possible
@@ -46,126 +46,126 @@ import { callAll } from 'lib0/function'
  * @public
  */
 export class Transaction {
-  /**
-   * @param {Doc} doc
-   * @param {any} origin
-   * @param {boolean} local
-   */
-  constructor (doc, origin, local) {
     /**
-     * The Yjs instance.
-     * @type {Doc}
+     * @param {Doc} doc
+     * @param {any} origin
+     * @param {boolean} local
      */
-    this.doc = doc
-    /**
-     * Describes the set of deleted items by ids
-     */
-    this.deleteSet = createIdSet()
-    /**
-     * Describes the set of items that are cleaned up / deleted by ids. It is a subset of
-     * this.deleteSet
-     */
-    this.cleanUps = createIdSet()
-    /**
-     * Describes the set of inserted items by ids
-     */
-    this.insertSet = createIdSet()
+    constructor(doc, origin, local) {
+        /**
+         * The Yjs instance.
+         * @type {Doc}
+         */
+        this.doc = doc
+        /**
+         * Describes the set of deleted items by ids
+         */
+        this.deleteSet = createIdSet()
+        /**
+         * Describes the set of items that are cleaned up / deleted by ids. It is a subset of
+         * this.deleteSet
+         */
+        this.cleanUps = createIdSet()
+        /**
+         * Describes the set of inserted items by ids
+         */
+        this.insertSet = createIdSet()
+        /**
+         * Holds the state before the transaction started.
+         * @type {Map<Number,Number>?}
+         */
+        this._beforeState = null
+        /**
+         * Holds the state after the transaction.
+         * @type {Map<Number,Number>?}
+         */
+        this._afterState = null
+        /**
+         * All types that were directly modified (property added or child
+         * inserted/deleted). New types are not included in this Set.
+         * Maps from type to parentSubs (`item.parentSub = null` for YArray)
+         * @type {Map<AbstractType<YEvent<any>>,Set<String|null>>}
+         */
+        this.changed = new Map()
+        /**
+         * Stores the events for the types that observe also child elements.
+         * It is mainly used by `observeDeep`.
+         * @type {Map<AbstractType<YEvent<any>>,Array<YEvent<any>>>}
+         */
+        this.changedParentTypes = new Map()
+        /**
+         * @type {Array<AbstractStruct>}
+         */
+        this._mergeStructs = []
+        /**
+         * @type {any}
+         */
+        this.origin = origin
+        /**
+         * Stores meta information on the transaction
+         * @type {Map<any,any>}
+         */
+        this.meta = new Map()
+        /**
+         * Whether this change originates from this doc.
+         * @type {boolean}
+         */
+        this.local = local
+        /**
+         * @type {Set<Doc>}
+         */
+        this.subdocsAdded = new Set()
+        /**
+         * @type {Set<Doc>}
+         */
+        this.subdocsRemoved = new Set()
+        /**
+         * @type {Set<Doc>}
+         */
+        this.subdocsLoaded = new Set()
+        /**
+         * @type {boolean}
+         */
+        this._needFormattingCleanup = false
+        this._done = false
+    }
+
     /**
      * Holds the state before the transaction started.
-     * @type {Map<Number,Number>?}
+     *
+     * @deprecated
+     * @type {Map<Number,Number>}
      */
-    this._beforeState = null
+    get beforeState() {
+        if (this._beforeState == null) {
+            const sv = getStateVector(this.doc.store)
+            this.insertSet.clients.forEach((ranges, client) => {
+                sv.set(client, ranges.getIds()[0].clock)
+            })
+            this._beforeState = sv
+        }
+        return this._beforeState
+    }
+
     /**
      * Holds the state after the transaction.
-     * @type {Map<Number,Number>?}
+     *
+     * @deprecated
+     * @type {Map<Number,Number>}
      */
-    this._afterState = null
-    /**
-     * All types that were directly modified (property added or child
-     * inserted/deleted). New types are not included in this Set.
-     * Maps from type to parentSubs (`item.parentSub = null` for YArray)
-     * @type {Map<AbstractType<YEvent<any>>,Set<String|null>>}
-     */
-    this.changed = new Map()
-    /**
-     * Stores the events for the types that observe also child elements.
-     * It is mainly used by `observeDeep`.
-     * @type {Map<AbstractType<YEvent<any>>,Array<YEvent<any>>>}
-     */
-    this.changedParentTypes = new Map()
-    /**
-     * @type {Array<AbstractStruct>}
-     */
-    this._mergeStructs = []
-    /**
-     * @type {any}
-     */
-    this.origin = origin
-    /**
-     * Stores meta information on the transaction
-     * @type {Map<any,any>}
-     */
-    this.meta = new Map()
-    /**
-     * Whether this change originates from this doc.
-     * @type {boolean}
-     */
-    this.local = local
-    /**
-     * @type {Set<Doc>}
-     */
-    this.subdocsAdded = new Set()
-    /**
-     * @type {Set<Doc>}
-     */
-    this.subdocsRemoved = new Set()
-    /**
-     * @type {Set<Doc>}
-     */
-    this.subdocsLoaded = new Set()
-    /**
-     * @type {boolean}
-     */
-    this._needFormattingCleanup = false
-    this._done = false
-  }
-
-  /**
-   * Holds the state before the transaction started.
-   *
-   * @deprecated
-   * @type {Map<Number,Number>}
-   */
-  get beforeState () {
-    if (this._beforeState == null) {
-      const sv = getStateVector(this.doc.store)
-      this.insertSet.clients.forEach((ranges, client) => {
-        sv.set(client, ranges.getIds()[0].clock)
-      })
-      this._beforeState = sv
+    get afterState() {
+        if (!this._done) error.unexpectedCase()
+        if (this._afterState == null) {
+            const sv = getStateVector(this.doc.store)
+            this.insertSet.clients.forEach((_ranges, client) => {
+                const ranges = _ranges.getIds()
+                const d = ranges[ranges.length - 1]
+                sv.set(client, d.clock + d.len)
+            })
+            this._afterState = sv
+        }
+        return this._afterState
     }
-    return this._beforeState
-  }
-
-  /**
-   * Holds the state after the transaction.
-   *
-   * @deprecated
-   * @type {Map<Number,Number>}
-   */
-  get afterState () {
-    if (!this._done) error.unexpectedCase()
-    if (this._afterState == null) {
-      const sv = getStateVector(this.doc.store)
-      this.insertSet.clients.forEach((_ranges, client) => {
-        const ranges = _ranges.getIds()
-        const d = ranges[ranges.length - 1]
-        sv.set(client, d.clock + d.len)
-      })
-      this._afterState = sv
-    }
-    return this._afterState
-  }
 }
 
 /**
@@ -174,12 +174,12 @@ export class Transaction {
  * @return {boolean} Whether data was written.
  */
 export const writeUpdateMessageFromTransaction = (encoder, transaction) => {
-  if (transaction.deleteSet.clients.size === 0 && transaction.insertSet.clients.size === 0) {
-    return false
-  }
-  writeStructsFromTransaction(encoder, transaction)
-  writeIdSet(encoder, transaction.deleteSet)
-  return true
+    if (transaction.deleteSet.clients.size === 0 && transaction.insertSet.clients.size === 0) {
+        return false
+    }
+    writeStructsFromTransaction(encoder, transaction)
+    writeIdSet(encoder, transaction.deleteSet)
+    return true
 }
 
 /**
@@ -189,8 +189,8 @@ export const writeUpdateMessageFromTransaction = (encoder, transaction) => {
  * @function
  */
 export const nextID = transaction => {
-  const y = transaction.doc
-  return createID(y.clientID, getState(y.store, y.clientID))
+    const y = transaction.doc
+    return createID(y.clientID, getState(y.store, y.clientID))
 }
 
 /**
@@ -202,10 +202,10 @@ export const nextID = transaction => {
  * @param {string|null} parentSub
  */
 export const addChangedTypeToTransaction = (transaction, type, parentSub) => {
-  const item = type._item
-  if (item === null || (!item.deleted && !transaction.insertSet.hasId(item.id))) {
-    map.setIfUndefined(transaction.changed, type, set.create).add(parentSub)
-  }
+    const item = type._item
+    if (item === null || (!item.deleted && !transaction.insertSet.hasId(item.id))) {
+        map.setIfUndefined(transaction.changed, type, set.create).add(parentSub)
+    }
 }
 
 /**
@@ -214,26 +214,26 @@ export const addChangedTypeToTransaction = (transaction, type, parentSub) => {
  * @return {number} # of merged structs
  */
 const tryToMergeWithLefts = (structs, pos) => {
-  let right = structs[pos]
-  let left = structs[pos - 1]
-  let i = pos
-  for (; i > 0; right = left, left = structs[--i - 1]) {
-    if (left.deleted === right.deleted && left.constructor === right.constructor) {
-      if (left.mergeWith(right)) {
-        if (right instanceof Item && right.parentSub !== null && /** @type {AbstractType<any>} */ (right.parent)._map.get(right.parentSub) === right) {
-          /** @type {AbstractType<any>} */ (right.parent)._map.set(right.parentSub, /** @type {Item} */ (left))
+    let right = structs[pos]
+    let left = structs[pos - 1]
+    let i = pos
+    for (; i > 0; right = left, left = structs[--i - 1]) {
+        if (left.deleted === right.deleted && left.constructor === right.constructor) {
+            if (left.mergeWith(right)) {
+                if (right instanceof Item && right.parentSub !== null && /** @type {AbstractType<any>} */ (right.parent)._map.get(right.parentSub) === right) {
+                    /** @type {AbstractType<any>} */ (right.parent)._map.set(right.parentSub, /** @type {Item} */ (left))
+                }
+                continue
+            }
         }
-        continue
-      }
+        break
     }
-    break
-  }
-  const merged = pos - i
-  if (merged) {
-    // remove all merged structs from the array
-    structs.splice(pos + 1 - merged, merged)
-  }
-  return merged
+    const merged = pos - i
+    if (merged) {
+        // remove all merged structs from the array
+        structs.splice(pos + 1 - merged, merged)
+    }
+    return merged
 }
 
 /**
@@ -242,27 +242,27 @@ const tryToMergeWithLefts = (structs, pos) => {
  * @param {function(Item):boolean} gcFilter
  */
 const tryGcDeleteSet = (tr, ds, gcFilter) => {
-  for (const [client, _deleteItems] of ds.clients.entries()) {
-    const deleteItems = _deleteItems.getIds()
-    const structs = /** @type {Array<GC|Item>} */ (tr.doc.store.clients.get(client))
-    for (let di = deleteItems.length - 1; di >= 0; di--) {
-      const deleteItem = deleteItems[di]
-      const endDeleteItemClock = deleteItem.clock + deleteItem.len
-      for (
-        let si = findIndexSS(structs, deleteItem.clock), struct = structs[si];
-        si < structs.length && struct.id.clock < endDeleteItemClock;
-        struct = structs[++si]
-      ) {
-        const struct = structs[si]
-        if (deleteItem.clock + deleteItem.len <= struct.id.clock) {
-          break
+    for (const [client, _deleteItems] of ds.clients.entries()) {
+        const deleteItems = _deleteItems.getIds()
+        const structs = /** @type {Array<GC|Item>} */ (tr.doc.store.clients.get(client))
+        for (let di = deleteItems.length - 1; di >= 0; di--) {
+            const deleteItem = deleteItems[di]
+            const endDeleteItemClock = deleteItem.clock + deleteItem.len
+            for (
+                let si = findIndexSS(structs, deleteItem.clock), struct = structs[si];
+                si < structs.length && struct.id.clock < endDeleteItemClock;
+                struct = structs[++si]
+            ) {
+                const struct = structs[si]
+                if (deleteItem.clock + deleteItem.len <= struct.id.clock) {
+                    break
+                }
+                if (struct instanceof Item && struct.deleted && !struct.keep && gcFilter(struct)) {
+                    struct.gc(tr, false)
+                }
+            }
         }
-        if (struct instanceof Item && struct.deleted && !struct.keep && gcFilter(struct)) {
-          struct.gc(tr, false)
-        }
-      }
     }
-  }
 }
 
 /**
@@ -270,24 +270,24 @@ const tryGcDeleteSet = (tr, ds, gcFilter) => {
  * @param {StructStore} store
  */
 const tryMerge = (ds, store) => {
-  // try to merge deleted / gc'd items
-  // merge from right to left for better efficiency and so we don't miss any merge targets
-  ds.clients.forEach((_deleteItems, client) => {
-    const deleteItems = _deleteItems.getIds()
-    const structs = /** @type {Array<GC|Item>} */ (store.clients.get(client))
-    for (let di = deleteItems.length - 1; di >= 0; di--) {
-      const deleteItem = deleteItems[di]
-      // start with merging the item next to the last deleted item
-      const mostRightIndexToCheck = math.min(structs.length - 1, 1 + findIndexSS(structs, deleteItem.clock + deleteItem.len - 1))
-      for (
-        let si = mostRightIndexToCheck, struct = structs[si];
-        si > 0 && struct.id.clock >= deleteItem.clock;
-        struct = structs[si]
-      ) {
-        si -= 1 + tryToMergeWithLefts(structs, si)
-      }
-    }
-  })
+    // try to merge deleted / gc'd items
+    // merge from right to left for better efficiency and so we don't miss any merge targets
+    ds.clients.forEach((_deleteItems, client) => {
+        const deleteItems = _deleteItems.getIds()
+        const structs = /** @type {Array<GC|Item>} */ (store.clients.get(client))
+        for (let di = deleteItems.length - 1; di >= 0; di--) {
+            const deleteItem = deleteItems[di]
+            // start with merging the item next to the last deleted item
+            const mostRightIndexToCheck = math.min(structs.length - 1, 1 + findIndexSS(structs, deleteItem.clock + deleteItem.len - 1))
+            for (
+                let si = mostRightIndexToCheck, struct = structs[si];
+                si > 0 && struct.id.clock >= deleteItem.clock;
+                struct = structs[si]
+            ) {
+                si -= 1 + tryToMergeWithLefts(structs, si)
+            }
+        }
+    })
 }
 
 /**
@@ -296,8 +296,8 @@ const tryMerge = (ds, store) => {
  * @param {function(Item):boolean} gcFilter
  */
 export const tryGc = (tr, idset, gcFilter) => {
-  tryGcDeleteSet(tr, idset, gcFilter)
-  tryMerge(idset, tr.doc.store)
+    tryGcDeleteSet(tr, idset, gcFilter)
+    tryMerge(idset, tr.doc.store)
 }
 
 /**
@@ -305,138 +305,138 @@ export const tryGc = (tr, idset, gcFilter) => {
  * @param {number} i
  */
 const cleanupTransactions = (transactionCleanups, i) => {
-  if (i < transactionCleanups.length) {
-    const transaction = transactionCleanups[i]
-    transaction._done = true
-    const doc = transaction.doc
-    const store = doc.store
-    const ds = transaction.deleteSet
-    const mergeStructs = transaction._mergeStructs
-    // insertIntoIdSet(store.ds, ds)
-    try {
-      doc.emit('beforeObserverCalls', [transaction, doc])
-      /**
-       * An array of event callbacks.
-       *
-       * Each callback is called even if the other ones throw errors.
-       *
-       * @type {Array<function():void>}
-       */
-      const fs = []
-      // observe events on changed types
-      transaction.changed.forEach((subs, itemtype) =>
-        fs.push(() => {
-          if (itemtype._item === null || !itemtype._item.deleted) {
-            itemtype._callObserver(transaction, subs)
-          }
-        })
-      )
-      fs.push(() => {
-        // deep observe events
-        transaction.changedParentTypes.forEach((events, type) => {
-          // We need to think about the possibility that the user transforms the
-          // Y.Doc in the event.
-          if (type._dEH.l.length > 0 && (type._item === null || !type._item.deleted)) {
-            events = events
-              .filter(event =>
-                event.target._item === null || !event.target._item.deleted
-              )
-            events
-              .forEach(event => {
-                event.currentTarget = type
-                // path is relative to the current target
-                event._path = null
-              })
-            // sort events by path length so that top-level events are fired first.
-            events
-              .sort((event1, event2) => event1.path.length - event2.path.length)
-            // We don't need to check for events.length
-            // because we know it has at least one element
-            callEventHandlerListeners(type._dEH, events, transaction)
-          }
-        })
-      })
-      fs.push(() => doc.emit('afterTransaction', [transaction, doc]))
-      callAll(fs, [])
-      if (transaction._needFormattingCleanup && doc.cleanupFormatting) {
-        cleanupYTextAfterTransaction(transaction)
-      }
-    } finally {
-      // Replace deleted items with ItemDeleted / GC.
-      // This is where content is actually remove from the Yjs Doc.
-      if (doc.gc) {
-        tryGcDeleteSet(transaction, ds, doc.gcFilter)
-      }
-      tryMerge(ds, store)
+    if (i < transactionCleanups.length) {
+        const transaction = transactionCleanups[i]
+        transaction._done = true
+        const doc = transaction.doc
+        const store = doc.store
+        const ds = transaction.deleteSet
+        const mergeStructs = transaction._mergeStructs
+        // insertIntoIdSet(store.ds, ds)
+        try {
+            doc.emit('beforeObserverCalls', [transaction, doc])
+            /**
+             * An array of event callbacks.
+             *
+             * Each callback is called even if the other ones throw errors.
+             *
+             * @type {Array<function():void>}
+             */
+            const fs = []
+            // observe events on changed types
+            transaction.changed.forEach((subs, itemtype) =>
+                fs.push(() => {
+                    if (itemtype._item === null || !itemtype._item.deleted) {
+                        itemtype._callObserver(transaction, subs)
+                    }
+                })
+            )
+            fs.push(() => {
+                // deep observe events
+                transaction.changedParentTypes.forEach((events, type) => {
+                    // We need to think about the possibility that the user transforms the
+                    // Y.Doc in the event.
+                    if (type._dEH.l.length > 0 && (type._item === null || !type._item.deleted)) {
+                        events = events
+                            .filter(event =>
+                                event.target._item === null || !event.target._item.deleted
+                            )
+                        events
+                            .forEach(event => {
+                                event.currentTarget = type
+                                // path is relative to the current target
+                                event._path = null
+                            })
+                        // sort events by path length so that top-level events are fired first.
+                        events
+                            .sort((event1, event2) => event1.path.length - event2.path.length)
+                        // We don't need to check for events.length
+                        // because we know it has at least one element
+                        callEventHandlerListeners(type._dEH, events, transaction)
+                    }
+                })
+            })
+            fs.push(() => doc.emit('afterTransaction', [transaction, doc]))
+            callAll(fs, [])
+            if (transaction._needFormattingCleanup && doc.cleanupFormatting) {
+                cleanupYTextAfterTransaction(transaction)
+            }
+        } finally {
+            // Replace deleted items with ItemDeleted / GC.
+            // This is where content is actually remove from the Yjs Doc.
+            if (doc.gc) {
+                tryGcDeleteSet(transaction, ds, doc.gcFilter)
+            }
+            tryMerge(ds, store)
 
-      // on all affected store.clients props, try to merge
-      transaction.insertSet.clients.forEach((ids, client) => {
-        const firstClock = ids.getIds()[0].clock
-        const structs = /** @type {Array<GC|Item>} */ (store.clients.get(client))
-        // we iterate from right to left so we can safely remove entries
-        const firstChangePos = math.max(findIndexSS(structs, firstClock), 1)
-        for (let i = structs.length - 1; i >= firstChangePos;) {
-          i -= 1 + tryToMergeWithLefts(structs, i)
-        }
-      })
-      // try to merge mergeStructs
-      // @todo: it makes more sense to transform mergeStructs to a DS, sort it, and merge from right to left
-      //        but at the moment DS does not handle duplicates
-      for (let i = mergeStructs.length - 1; i >= 0; i--) {
-        const { client, clock } = mergeStructs[i].id
-        const structs = /** @type {Array<GC|Item>} */ (store.clients.get(client))
-        const replacedStructPos = findIndexSS(structs, clock)
-        if (replacedStructPos + 1 < structs.length) {
-          if (tryToMergeWithLefts(structs, replacedStructPos + 1) > 1) {
-            continue // no need to perform next check, both are already merged
-          }
-        }
-        if (replacedStructPos > 0) {
-          tryToMergeWithLefts(structs, replacedStructPos)
-        }
-      }
-      if (!transaction.local && transaction.insertSet.clients.has(doc.clientID)) {
-        logging.print(logging.ORANGE, logging.BOLD, '[yjs] ', logging.UNBOLD, logging.RED, 'Changed the client-id because another client seems to be using it.')
-        doc.clientID = generateNewClientId()
-      }
-      // @todo Merge all the transactions into one and provide send the data as a single update message
-      doc.emit('afterTransactionCleanup', [transaction, doc])
-      if (doc._observers.has('update')) {
-        const encoder = new UpdateEncoderV1()
-        const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
-        if (hasContent) {
-          doc.emit('update', [encoder.toUint8Array(), transaction.origin, doc, transaction])
-        }
-      }
-      if (doc._observers.has('updateV2')) {
-        const encoder = new UpdateEncoderV2()
-        const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
-        if (hasContent) {
-          doc.emit('updateV2', [encoder.toUint8Array(), transaction.origin, doc, transaction])
-        }
-      }
-      const { subdocsAdded, subdocsLoaded, subdocsRemoved } = transaction
-      if (subdocsAdded.size > 0 || subdocsRemoved.size > 0 || subdocsLoaded.size > 0) {
-        subdocsAdded.forEach(subdoc => {
-          subdoc.clientID = doc.clientID
-          if (subdoc.collectionid == null) {
-            subdoc.collectionid = doc.collectionid
-          }
-          doc.subdocs.add(subdoc)
-        })
-        subdocsRemoved.forEach(subdoc => doc.subdocs.delete(subdoc))
-        doc.emit('subdocs', [{ loaded: subdocsLoaded, added: subdocsAdded, removed: subdocsRemoved }, doc, transaction])
-        subdocsRemoved.forEach(subdoc => subdoc.destroy())
-      }
+            // on all affected store.clients props, try to merge
+            transaction.insertSet.clients.forEach((ids, client) => {
+                const firstClock = ids.getIds()[0].clock
+                const structs = /** @type {Array<GC|Item>} */ (store.clients.get(client))
+                // we iterate from right to left so we can safely remove entries
+                const firstChangePos = math.max(findIndexSS(structs, firstClock), 1)
+                for (let i = structs.length - 1; i >= firstChangePos;) {
+                    i -= 1 + tryToMergeWithLefts(structs, i)
+                }
+            })
+            // try to merge mergeStructs
+            // @todo: it makes more sense to transform mergeStructs to a DS, sort it, and merge from right to left
+            //        but at the moment DS does not handle duplicates
+            for (let i = mergeStructs.length - 1; i >= 0; i--) {
+                const {client, clock} = mergeStructs[i].id
+                const structs = /** @type {Array<GC|Item>} */ (store.clients.get(client))
+                const replacedStructPos = findIndexSS(structs, clock)
+                if (replacedStructPos + 1 < structs.length) {
+                    if (tryToMergeWithLefts(structs, replacedStructPos + 1) > 1) {
+                        continue // no need to perform next check, both are already merged
+                    }
+                }
+                if (replacedStructPos > 0) {
+                    tryToMergeWithLefts(structs, replacedStructPos)
+                }
+            }
+            if (!transaction.local && transaction.insertSet.clients.has(doc.clientID)) {
+                logging.print(logging.ORANGE, logging.BOLD, '[yjs] ', logging.UNBOLD, logging.RED, 'Changed the client-id because another client seems to be using it.')
+                doc.clientID = generateNewClientId()
+            }
+            // @todo Merge all the transactions into one and provide send the data as a single update message
+            doc.emit('afterTransactionCleanup', [transaction, doc])
+            if (doc._observers.has('update')) {
+                const encoder = new UpdateEncoderV1()
+                const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
+                if (hasContent) {
+                    doc.emit('update', [encoder.toUint8Array(), transaction.origin, doc, transaction])
+                }
+            }
+            if (doc._observers.has('updateV2')) {
+                const encoder = new UpdateEncoderV2()
+                const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
+                if (hasContent) {
+                    doc.emit('updateV2', [encoder.toUint8Array(), transaction.origin, doc, transaction])
+                }
+            }
+            const {subdocsAdded, subdocsLoaded, subdocsRemoved} = transaction
+            if (subdocsAdded.size > 0 || subdocsRemoved.size > 0 || subdocsLoaded.size > 0) {
+                subdocsAdded.forEach(subdoc => {
+                    subdoc.clientID = doc.clientID
+                    if (subdoc.collectionid == null) {
+                        subdoc.collectionid = doc.collectionid
+                    }
+                    doc.subdocs.add(subdoc)
+                })
+                subdocsRemoved.forEach(subdoc => doc.subdocs.delete(subdoc))
+                doc.emit('subdocs', [{loaded: subdocsLoaded, added: subdocsAdded, removed: subdocsRemoved}, doc, transaction])
+                subdocsRemoved.forEach(subdoc => subdoc.destroy())
+            }
 
-      if (transactionCleanups.length <= i + 1) {
-        doc._transactionCleanups = []
-        doc.emit('afterAllTransactions', [doc, transactionCleanups])
-      } else {
-        cleanupTransactions(transactionCleanups, i + 1)
-      }
+            if (transactionCleanups.length <= i + 1) {
+                doc._transactionCleanups = []
+                doc.emit('afterAllTransactions', [doc, transactionCleanups])
+            } else {
+                cleanupTransactions(transactionCleanups, i + 1)
+            }
+        }
     }
-  }
 }
 
 /**
@@ -451,39 +451,83 @@ const cleanupTransactions = (transactionCleanups, i) => {
  * @function
  */
 export const transact = (doc, f, origin = null, local = true) => {
-  const transactionCleanups = doc._transactionCleanups
-  let initialCall = false
-  /**
-   * @type {any}
-   */
-  let result = null
-  if (doc._transaction === null) {
-    initialCall = true
-    doc._transaction = new Transaction(doc, origin, local)
-    transactionCleanups.push(doc._transaction)
-    if (transactionCleanups.length === 1) {
-      doc.emit('beforeAllTransactions', [doc])
+    const transactionCleanups = doc._transactionCleanups
+    let initialCall = false
+    /**
+     * @type {any}
+     */
+    let result = null
+    if (doc._transaction === null) {
+        initialCall = true
+        doc._transaction = new Transaction(doc, origin, local)
+        transactionCleanups.push(doc._transaction)
+        if (transactionCleanups.length === 1) {
+            doc.emit('beforeAllTransactions', [doc])
+        }
+        doc.emit('beforeTransaction', [doc._transaction, doc])
     }
-    doc.emit('beforeTransaction', [doc._transaction, doc])
-  }
-  try {
-    result = f(doc._transaction)
-  } finally {
-    if (initialCall) {
-      const finishCleanup = doc._transaction === transactionCleanups[0]
-      doc._transaction = null
-      if (finishCleanup) {
-        // The first transaction ended, now process observer calls.
-        // Observer call may create new transactions for which we need to call the observers and do cleanup.
-        // We don't want to nest these calls, so we execute these calls one after
-        // another.
-        // Also we need to ensure that all cleanups are called, even if the
-        // observes throw errors.
-        // This file is full of hacky try {} finally {} blocks to ensure that an
-        // event can throw errors and also that the cleanup is called.
-        cleanupTransactions(transactionCleanups, 0)
-      }
+    try {
+        result = f(doc._transaction)
+    } finally {
+        if (initialCall) {
+            const finishCleanup = doc._transaction === transactionCleanups[0]
+            doc._transaction = null
+            if (finishCleanup) {
+                // The first transaction ended, now process observer calls.
+                // Observer call may create new transactions for which we need to call the observers and do cleanup.
+                // We don't want to nest these calls, so we execute these calls one after
+                // another.
+                // Also we need to ensure that all cleanups are called, even if the
+                // observes throw errors.
+                // This file is full of hacky try {} finally {} blocks to ensure that an
+                // event can throw errors and also that the cleanup is called.
+                cleanupTransactions(transactionCleanups, 0)
+            }
+        }
     }
-  }
-  return result
+    return result
+}
+
+/**
+ * Implement the functionality of
+ *
+ * ```js
+ * [tx, endTransaction] = y.beginTransaction(()=>{..});
+ * ...
+ * endTransaction();
+ * ```
+ *
+ * @param {Doc} doc
+ * @param {any} [origin=null]
+ * @param {boolean} [local=true]
+ * @return {[Transaction, function():void]}
+ *
+ * @public
+ * @function
+ */
+export const beginTransaction = (doc, origin = null, local = true) => {
+    const transactionCleanups = doc._transactionCleanups
+    let initialCall = false
+    if (doc._transaction === null) {
+        initialCall = true
+        doc._transaction = new Transaction(doc, origin, local)
+        transactionCleanups.push(doc._transaction)
+        if (transactionCleanups.length === 1) {
+            doc.emit('beforeAllTransactions', [doc])
+        }
+        doc.emit('beforeTransaction', [doc._transaction, doc])
+    }
+    return [
+        doc._transaction,
+        () => {
+            if (initialCall) {
+                const finishCleanup = doc._transaction === transactionCleanups[0]
+                doc._transaction = null
+                if (finishCleanup) {
+                    // The first transaction ended, now process observer calls and cleanup.
+                    cleanupTransactions(transactionCleanups, 0)
+                }
+            }
+        }
+    ]
 }

--- a/tests/doc.tests.js
+++ b/tests/doc.tests.js
@@ -22,6 +22,28 @@ export const testAfterTransactionRecursion = _tc => {
 /**
  * @param {t.TestCase} _tc
  */
+export const testBeginTransaction = _tc => {
+  // Same as testAfterTransactionRecursion, but using beginTransaction
+  const ydoc = new Y.Doc()
+  const yxml = ydoc.getXmlFragment('')
+  ydoc.on('afterTransaction', tr => {
+    if (tr.origin === 'test') {
+      yxml.toJSON()
+    }
+  })
+  const [tx, endTransaction] = ydoc.beginTransaction('test');
+  try {
+      for (let i = 0; i < 15000; i++) {
+      yxml.push([new Y.XmlText('a')])
+      }
+  } finally {
+      endTransaction()
+  }
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
 export const testFindTypeInOtherDoc = _tc => {
   const ydoc = new Y.Doc()
   const ymap = ydoc.getMap()


### PR DESCRIPTION
Hello,

This PR introduces doc.beginTransaction() which start a transaction and return a finisher callback. It lets callers wrap transaction code with try/finally instead of passing a function to transact.

This is useful when a callback isn’t feasible, e.g., integrating with code that expects begin/end semantic, so the transaction can span arbitrary control flow and multiple functions.

```js
const ydoc = new Y.Doc()
const yxml = ydoc.getXmlFragment('')

const endTransaction = ydoc.beginTransaction('bulk')
try {
  for (let i = 0; i < 10; i++) yxml.push([new Y.XmlText('a')])
} finally {
  endTransaction()
}
```