### PR TITLE
README: add mutative-yjs bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ are implemented in separate modules.
 | [Superdoc](https://superdoc.dev/) | ✔ | (native) | [demo](https://superdoc.dev/) |
 | [valtio](https://github.com/pmndrs/valtio) |  | [valtio-yjs](https://github.com/dai-shi/valtio-yjs) | [demo](https://codesandbox.io/s/valtio-yjs-demo-ox3iy) |
 | [immer](https://github.com/immerjs/immer) |  | [immer-yjs](https://github.com/sep2/immer-yjs) | [demo](https://codesandbox.io/s/immer-yjs-demo-6e0znb) |
+| [mutative](https://github.com/unadlib/mutative) |  | [mutative-yjs](https://github.com/mutativejs/mutative-yjs) | [demo](https://codesandbox.io/p/sandbox/fjrwk3) |
 | React | | [react-yjs](https://github.com/nikgraf/react-yjs) | [demo](https://react-yjs-example.vercel.app/) |
 | React / Vue / Svelte / MobX | | [SyncedStore](https://syncedstore.org) | [demo](https://syncedstore.org/docs/react) |
 | [mobx-keystone](https://mobx-keystone.js.org/) |  | [mobx-keystone-yjs](https://github.com/xaviergonz/mobx-keystone/tree/master/packages/mobx-keystone-yjs) | [demo](https://mobx-keystone.js.org/examples/yjs-binding) |


### PR DESCRIPTION
Added the `mutative-yjs` Yjs bindings to the README.

GitHub: https://github.com/mutativejs/mutative-yjs
Demo: https://codesandbox.io/p/sandbox/fjrwk3