### PR TITLE
Fix tests by using an ES module loader when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "test": "NODE_ENV=development node ./tests/index.js --repetition-time 50",
+    "test": "NODE_ENV=development node --loader ./tests/yjs-alias-loader.js ./tests/index.js --repetition-time 50",
     "test-extensive": "node ./tests/index.js --production --repetition-time 10000",
     "dist": "npm run clean && rollup -c && tsc --skipLibCheck",
     "watch": "rollup -wc",

--- a/tests/yjs-alias-loader.js
+++ b/tests/yjs-alias-loader.js
@@ -1,0 +1,15 @@
+import { pathToFileURL } from 'url'
+
+/**
+ *
+ * @param {*} specifier
+ * @param {*} context
+ * @param {*} nextResolve
+ */
+export async function resolve (specifier, context, nextResolve) {
+  if (specifier === 'yjs') {
+    // Redirect all yjs imports to the local YJS implementation to avoid loading multiple YJS instances
+    return nextResolve(pathToFileURL('./src/index.js').href, context)
+  }
+  return nextResolve(specifier, context)
+}


### PR DESCRIPTION
Because of transitive dependencies, a Y.js dependency is installed under node_modules and is imported by @y/protocols package that's used in some Y.js tests. This import causes two separate Y.js instances to be loaded, which in turn wreaks havoc, as a lot of `instanceof` or other checks in the Y.js core code start to fail.

This Pull Request solves the problem by adding a `--loader` parameter to Node.js when running tests. The given loader script always loads `./src/index.js` instead of anything under `node_modules` when the package `yjs` is loaded by any of our devDependencies.

This solves #745. I have tested this locally with Node.js versions 16 and 24.