### PR TITLE
Remove try-catch, improve error messages

### DIFF
--- a/src/types/YArray.js
+++ b/src/types/YArray.js
@@ -71,6 +71,9 @@ export class YArray extends AbstractType {
    */
   _integrate (y, item) {
     super._integrate(y, item)
+    if (!this._prelimContent) {
+      throw Error('YArray was already added to a document')
+    }
     this.insert(0, /** @type {Array<any>} */ (this._prelimContent))
     this._prelimContent = null
   }

--- a/src/types/YMap.js
+++ b/src/types/YMap.js
@@ -57,6 +57,9 @@ export class YMap extends AbstractType {
    */
   _integrate (y, item) {
     super._integrate(y, item)
+    if (!this._prelimContent) {
+      throw Error('YMap was already added to a document')
+    }
     ;/** @type {Map<string, any>} */ (this._prelimContent).forEach((value, key) => {
       this.set(key, value)
     })

--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -670,7 +670,10 @@ export class YText extends AbstractType {
    * @param {Item?} item
    */
   _integrate (y, item) {
-    super._integrate(y, item);
+    super._integrate(y, item)
+    if (!this._pending) {
+      throw Error('YText was already added to a document')
+    }
     /** @type {Array<function>} */ (this._pending).forEach(f => f())
     this._pending = null
   }

--- a/src/types/YText.js
+++ b/src/types/YText.js
@@ -670,12 +670,8 @@ export class YText extends AbstractType {
    * @param {Item?} item
    */
   _integrate (y, item) {
-    super._integrate(y, item)
-    try {
-      /** @type {Array<function>} */ (this._pending).forEach(f => f())
-    } catch (e) {
-      console.error(e)
-    }
+    super._integrate(y, item);
+    /** @type {Array<function>} */ (this._pending).forEach(f => f())
     this._pending = null
   }
 

--- a/src/types/YXmlFragment.js
+++ b/src/types/YXmlFragment.js
@@ -83,6 +83,9 @@ export class YXmlFragment extends AbstractType {
    */
   _integrate (y, item) {
     super._integrate(y, item)
+    if (!this._prelimContent) {
+      throw Error('YArray was already added to a document')
+    }
     this.insert(0, /** @type {Array<any>} */ (this._prelimContent))
     this._prelimContent = null
   }

--- a/tests/doc.tests.js
+++ b/tests/doc.tests.js
@@ -359,7 +359,7 @@ export const testAddTextToDocTwice = async _tc => {
   const mainMap = ydoc.getMap('test')
   const text = new Y.Text()
   mainMap.set('text', text)
-  expectThrows(() => mainMap.set('text2', text))  
+  expectThrows(() => mainMap.set('text2', text))
 }
 
 /**
@@ -368,11 +368,9 @@ export const testAddTextToDocTwice = async _tc => {
 export const testAddMapToDocTwice = async _tc => {
   const ydoc = new Y.Doc()
   const mainMap = ydoc.getMap('test')
-  const text = new Y.Text()
-  
   const map = new Y.Map()
   mainMap.set('map', map)
-  expectThrows(() => mainMap.set('map2', map))  
+  expectThrows(() => mainMap.set('map2', map))
 }
 
 /**
@@ -382,16 +380,14 @@ export const testAddArrayToDocTwice = async _tc => {
   const ydoc = new Y.Doc()
   const mainMap = ydoc.getMap('test')
   const array = new Y.Array()
-  
-  const map = new Y.Map()
   mainMap.set('array', array)
-  expectThrows(() => mainMap.set('array2', array))  
+  expectThrows(() => mainMap.set('array2', array))
 }
 
 /**
- * @param {*} f 
+ * @param {*} f
  */
-function expectThrows(f) {
+function expectThrows (f) {
   let success = false
   try {
     f()
@@ -401,6 +397,6 @@ function expectThrows(f) {
     // Expected to throw
   }
   if (success) {
-    t.fail("Expected to throw")
+    t.fail('Expected to throw')
   }
 }

--- a/tests/doc.tests.js
+++ b/tests/doc.tests.js
@@ -350,3 +350,57 @@ export const testSyncDocsEvent = async _tc => {
   t.assert(!ydoc.isSynced)
   t.assert(ydoc.whenSynced !== oldWhenSynced)
 }
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testAddTextToDocTwice = async _tc => {
+  const ydoc = new Y.Doc()
+  const mainMap = ydoc.getMap('test')
+  const text = new Y.Text()
+  mainMap.set('text', text)
+  expectThrows(() => mainMap.set('text2', text))  
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testAddMapToDocTwice = async _tc => {
+  const ydoc = new Y.Doc()
+  const mainMap = ydoc.getMap('test')
+  const text = new Y.Text()
+  
+  const map = new Y.Map()
+  mainMap.set('map', map)
+  expectThrows(() => mainMap.set('map2', map))  
+}
+
+/**
+ * @param {t.TestCase} _tc
+ */
+export const testAddArrayToDocTwice = async _tc => {
+  const ydoc = new Y.Doc()
+  const mainMap = ydoc.getMap('test')
+  const array = new Y.Array()
+  
+  const map = new Y.Map()
+  mainMap.set('array', array)
+  expectThrows(() => mainMap.set('array2', array))  
+}
+
+/**
+ * @param {*} f 
+ */
+function expectThrows(f) {
+  let success = false
+  try {
+    f()
+    success = true
+    throw new Error('Function did not throw')
+  } catch (e) {
+    // Expected to throw
+  }
+  if (success) {
+    t.fail("Expected to throw")
+  }
+}


### PR DESCRIPTION
Fixes #744, given that the try-catch indeed is unintended.

Also adds more descriptive error messages for the cases where the application tries to integrate a shared type to a document, while it's already integrated.