### PR TITLE
feat: `beforeTransactionBuilt` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,8 @@ to receive V2 events.
   </dd>
   <b><code>on('beforeTransaction', function(Y.Transaction, Y.Doc):void)</code></b>
   <dd>Emitted before each transaction.</dd>
+  <b><code>on('beforeTransactionBuilt', function(Y.Transaction, Y.Doc):void)</code></b>
+  <dd>Emitted after each transaction is built but before commited.</dd>
   <b><code>on('afterTransaction', function(Y.Transaction, Y.Doc):void)</code></b>
   <dd>Emitted after each transaction.</dd>
   <b><code>on('beforeAllTransactions', function(Y.Doc):void)</code></b>

--- a/src/utils/Doc.js
+++ b/src/utils/Doc.js
@@ -54,6 +54,7 @@ export const generateNewClientId = random.uint32
  * @property {function(Uint8Array<ArrayBuffer>, any, Doc, Transaction):void} DocEvents.updateV2
  * @property {function(Doc):void} DocEvents.beforeAllTransactions
  * @property {function(Transaction, Doc):void} DocEvents.beforeTransaction
+ * @property {function(Transaction, Doc):void} DocEvents.beforeTransactionBuilt
  * @property {function(Transaction, Doc):void} DocEvents.beforeObserverCalls
  * @property {function(Transaction, Doc):void} DocEvents.afterTransaction
  * @property {function(Transaction, Doc):void} DocEvents.afterTransactionCleanup

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -470,6 +470,7 @@ export const transact = (doc, f, origin = null, local = true) => {
     result = f(doc._transaction)
   } finally {
     if (initialCall) {
+      doc.emit('beforeTransactionBuilt', [doc._transaction, doc])
       const finishCleanup = doc._transaction === transactionCleanups[0]
       doc._transaction = null
       if (finishCleanup) {


### PR DESCRIPTION
This PR introduces a `beforeTransactionBuilt` event in `Y.Doc`. This event fires after the transaction is built (after the `ydoc.transact()` callback finishes) but before the transaction is committed.

The purpose of the `beforeTransactionBuilt` event is adding modifications to the document in response to other modifications somewhere else in **the same transaction**. Having the extra modifications in the same transaction ensures proper undo/redo and synchronization. My use-case is updating the document metadata when something changes deep inside the document:

```js
ydoc.on("beforeTransactionBuilt", (transaction) => {
  // Watching only user-made changes
  if (transaction.origin === null) {
    ydoc.getMap("metadata").set("modifiedAt", new Date().toISOString());
  }
});
```

<details><summary>Alternative solutions and why they don't work</summary>

## `beforeObserverCalls`

```js
ydoc.on("beforeObserverCalls", (transaction) => {
  if (transaction.origin === null) {
    ydoc.getMap("metadata").set("modifiedAt", new Date().toISOString());
  }
});
```

Creates another transaction.

## Wrapping all my document modifications

```js
function myTransact(ydoc, f) {
  return ydoc.transact(() => {
    const result = f();

    ydoc.getMap("metadata").set("modifiedAt", new Date().toISOString());

    return result;
  });
}

myTransact(ydoc, () => {
  ydoc.getMap("foo").set("bar", "baz");
});
```

It doesn't work with third-party libraries, such as `y-prosemirror`.

## Hijacking `transact`

```js
const originalTransact = ydoc.transact.bind(ydoc);

ydoc.transact = (f, origin) => {
  return originalTransact((transaction, doc) => {
    const result = f(transaction, doc);

    if (transaction.origin === null) {
      ydoc.getMap("metadata").set("modifiedAt", new Date().toISOString());
    }

    return result;
  }, origin);
};
```

Works well for changes made inside `ydoc.transact`, but doesn't work for changes outside `ydoc.transact`.

</details>

I'm not 100% happy with the `beforeTransactionBuilt` event name, so I'm open for suggestions.

I'm not sure whether there should be a separate "all" event. According to the source code and my experiments, `beforeTransaction` and `beforeAllTransactions` events are always emitted together, so I don't understand how the "all" version should work.