### PR TITLE
fix: if there is not element to modify, throw an error

### DIFF
--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -736,7 +736,11 @@ export class AbstractType {
           } else if (delta.$deleteOp.check(op)) {
             deleteText(transaction, currPos, op.delete)
           } else if (delta.$modifyOp.check(op)) {
-            /** @type {ContentType} */ (currPos.right?.content).type.applyDelta(op.value)
+            if (currPos.right) {
+              /** @type {ContentType} */ (currPos.right.content).type.applyDelta(op.value)
+            } else {
+              error.unexpectedCase()
+            }
             currPos.formatText(transaction, /** @type {any} */ (this), 1, op.format || {})
           } else {
             error.unexpectedCase()


### PR DESCRIPTION
This is a minor bug fix for something which I ran into.

if `currPos.right` is null, then we should be throwing an error that the modify op is not going actually take effect (before it was being silently skipped)
