### PR TITLE
docs: fix broken Liveblocks Yjs documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ document private.
   </dd>
   <dt><a href="https://github.com/liveblocks/liveblocks">@liveblocks/yjs </a> 🌟</dt>
   <dd>
-<a href="https://liveblocks.io/document/yjs">Liveblocks Yjs</a> provides a fully
+<a href="https://liveblocks.io/docs/api-reference/liveblocks-yjs">Liveblocks Yjs</a> provides a fully
 hosted WebSocket infrastructure and persisted data store for Yjs
 documents. No configuration or maintenance is required. It also features
 Yjs webhook events, REST API to read and update Yjs documents, and a


### PR DESCRIPTION
Update the Liveblocks Yjs link from the outdated URL (https://liveblocks.io/document/yjs) which returns a 404 error to the current API reference documentation at
https://liveblocks.io/docs/api-reference/liveblocks-yjs