### PR TITLE
[applyDelta] allow specifying origin and local for the `applyDelta` transaction

### DIFF
--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -704,10 +704,13 @@ export class AbstractType {
    *
    * @param {delta.Delta<any,any,any,any,any>} d The changes to apply on this element.
    * @param {AbstractAttributionManager} am
+   * @param {object} [opts]
+   * @param {any} [opts.origin] - The origin of the transaction
+   * @param {boolean} [opts.local] - Whether the transaction is local
    *
    * @public
    */
-  applyDelta (d, am = noAttributionsManager) {
+  applyDelta (d, am = noAttributionsManager, opts = {}) {
     if (this.doc == null) {
       (this._prelim || (this._prelim = /** @type {any} */ (delta.create()))).apply(d)
     } else {
@@ -759,7 +762,7 @@ export class AbstractType {
             sub.applyDelta(op.value)
           }
         }
-      })
+      }, opts.origin, opts.local)
     }
   }
 }


### PR DESCRIPTION
I figured that it was useful for the `applyDelta` to allow specifying the origin for the transaction (so that I can filter by the origin, like I normally would).

I wasn't sure whether the `local` option needed to be configurable or not, but I included it anyway.

I also wasn't sure whether the attributionsManager should actually be under this new `opts` object. But, I didn't want to break the interface so I just added it as another param
