### PR TITLE
expose `SnapshotAttributionManager` and `createAttributionManagerFromSnapshots`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,8 @@ export {
   iterateStructsByIdSet,
   createAttributionManagerFromDiff,
   DiffAttributionManager,
+  createAttributionManagerFromSnapshots,
+  SnapshotAttributionManager,
   createIdSet,
   mergeIdSets,
   cloneDoc,


### PR DESCRIPTION
These just were not exposed in the public API
