### PR TITLE
add `acceptAllChanges` & `rejectAllChanges` APIs to `DiffAttributionManager`

### DIFF
--- a/src/utils/AttributionManager.js
+++ b/src/utils/AttributionManager.js
@@ -446,8 +446,9 @@ export class DiffAttributionManager extends ObservableV2 {
   }
 
   /**
+   * Accept all changes between start {@link ID} and end {@link ID}.
    * @param {ID} start
-   * @param {ID} end
+   * @param {ID} [end]
    */
   acceptChanges (start, end = start) {
     const { inserts, deletes } = collectSuggestedChanges(null, this, start, end, true)
@@ -458,8 +459,9 @@ export class DiffAttributionManager extends ObservableV2 {
   }
 
   /**
+   * Reject all changes between start {@link ID} and end {@link ID}.
    * @param {ID} start
-   * @param {ID} end
+   * @param {ID} [end]
    */
   rejectChanges (start, end = start) {
     this._nextDoc.transact(tr => {
@@ -473,6 +475,30 @@ export class DiffAttributionManager extends ObservableV2 {
       um.destroy()
     })
     this.acceptChanges(start, end)
+  }
+
+  /**
+   * Accept all changes from the next document.
+   * @param {import('./types.js').YType} type - Accept all changes within the type
+   */
+  acceptAllChanges (type) {
+    const id = type._item?.id
+    if (!id) {
+      error.unexpectedCase()
+    }
+
+    this.acceptChanges(id)
+  }
+
+  /**
+   * Reject all changes from the next document.
+   * @param {import('./types.js').YType} type - Reject all changes within the type
+   */
+  rejectAllChanges (type) {
+    const id = type._item?.id
+    if (!id) {
+      error.unexpectedCase()
+    }
   }
 
   /**


### PR DESCRIPTION
I'm not totally certain if this is correct or not. But based on my understanding of `collectSuggestedChanges`, this should allow us to move all suggestions from the suggestion doc within the ytype into the main document.

The goal here is to provide an API where we can accept/reject all of the changes

On second thought, for accepting changes, it would just be equivalent of encoding the suggestion doc and moving it wholesale into the main doc, but I'm not sure that rejecting changes will be that easy then.
Either way, this is more convenient than having to know how it works in the underlying implementation
