### PR TITLE
Clean up non-primitive formatting values correctly

### DIFF
--- a/src/utils/transaction-helpers.js
+++ b/src/utils/transaction-helpers.js
@@ -395,7 +395,11 @@ export const cleanupFormattingGap = (transaction, start, curr, startAttributes, 
           start.delete(transaction)
           transaction.cleanUps.add(start.id.client, start.id.clock, start.length)
           cleanups++
-          if (!reachedCurr && (currAttributes.get(key) ?? null) === value && startAttrValue !== value) {
+          if (
+            !reachedCurr &&
+            equalAttrs((currAttributes.get(key) ?? null), value) &&
+            !equalAttrs(startAttrValue, value)
+          ) {
             if (startAttrValue === null) {
               currAttributes.delete(key)
             } else {

--- a/src/utils/transaction-helpers.js
+++ b/src/utils/transaction-helpers.js
@@ -1,15 +1,22 @@
 import * as math from 'lib0/math'
+import * as object from 'lib0/object'
 import * as error from 'lib0/error'
 import * as map from 'lib0/map'
 import * as set from 'lib0/set'
 
 import { createID } from './ID.js'
-import { equalAttrs } from '../ytype.js'
 
 /**
  * These modules don't require any imports.
  * These helpers are used by items to integrate themselves
  */
+
+/**
+ * @param {any} a
+ * @param {any} b
+ * @return {boolean}
+ */
+export const equalAttrs = (a, b) => a === b || (typeof a === 'object' && typeof b === 'object' && a && b && object.equalFlat(a, b))
 
 /**
  * Perform a binary search on a sorted array

--- a/src/utils/transaction-helpers.js
+++ b/src/utils/transaction-helpers.js
@@ -4,6 +4,7 @@ import * as map from 'lib0/map'
 import * as set from 'lib0/set'
 
 import { createID } from './ID.js'
+import { equalAttrs } from '../ytype.js'
 
 /**
  * These modules don't require any imports.
@@ -389,7 +390,7 @@ export const cleanupFormattingGap = (transaction, start, curr, startAttributes, 
       if (content.getRef() === 6) { // is ContentFormat
         const { key, value } = /** @type {ContentFormat} */ (content)
         const startAttrValue = startAttributes.get(key) ?? null
-        if (endFormats.get(key) !== content || startAttrValue === value) {
+        if (endFormats.get(key) !== content || equalAttrs(startAttrValue, value)) {
           // Either this format is overwritten or it is not necessary because the attribute already existed.
           start.delete(transaction)
           transaction.cleanUps.add(start.id.client, start.id.clock, start.length)

--- a/src/ytype.js
+++ b/src/ytype.js
@@ -30,7 +30,7 @@ import { noAttributionsManager } from './utils/attribution-manager-helpers.js'
 import { removeEventHandlerListener, callEventHandlerListeners, addEventHandlerListener, createEventHandler } from './utils/EventHandler.js'
 import { createID } from './utils/ID.js'
 import { createIdSet, iterateStructsByIdSetWithoutSplits } from './utils/ids.js'
-import { getItemCleanStart, cleanupFormattingGap } from './utils/transaction-helpers.js'
+import { getItemCleanStart, cleanupFormattingGap, equalAttrs } from './utils/transaction-helpers.js'
 import { transact } from './utils/Transaction.js'
 import { YEvent } from './utils/YEvent.js'
 import { $ydoc } from './utils/schemas.js'
@@ -1511,13 +1511,6 @@ export const computeModifiedFromItems = (store, items) => {
   })
   return modified
 }
-
-/**
- * @param {any} a
- * @param {any} b
- * @return {boolean}
- */
-export const equalAttrs = (a, b) => a === b || (typeof a === 'object' && typeof b === 'object' && a && b && object.equalFlat(a, b))
 
 /**
  * @template {delta.DeltaConf} DConf

--- a/tests/y-text.tests.js
+++ b/tests/y-text.tests.js
@@ -1252,6 +1252,36 @@ export const testDeltaAfterConcurrentFormatting = tc => {
 }
 
 /**
+ * https://github.com/yjs/yjs/issues/776
+ * @param {t.TestCase} _tc
+ */
+export const testDeletingTextWithNonPrimitiveFormatting = _tc => {
+  const ydoc = new Y.Doc({ gc: false })
+  const testText = ydoc.get('test')
+  testText.insert(0, 'one two three', { bold: { active: false } })
+  testText.format(4, 9, { bold: { active: true } })
+  testText.format(7, 6, { bold: { active: false } })
+  testText.delete(2, 9)
+  /**
+   * @type {Y.Item | null}
+   */
+  let twoItem = null
+  for (let item = testText._start; item; item = item.right) {
+    const { content } = item
+    if (content instanceof Y.ContentString && content.str === 'two') {
+      twoItem = item
+    }
+  }
+  t.assert(twoItem, 'could not find twoItem')
+  t.assert(twoItem.deleted, 'expected twoItem to be deleted')
+  const formatItem = twoItem.right
+  t.assert(formatItem?.content instanceof Y.ContentFormat, 'expected ContentFormat')
+  const formatContent = /** @type {Y.ContentFormat } */ (formatItem?.content)
+  t.compare(formatContent.value, { active: false }, 'unexpected ContentFormat value')
+  t.assert(formatItem?.deleted, 'expected ContentFormat item to be deleted')
+}
+
+/**
  * @param {t.TestCase} tc
  */
 export const testBasicInsertAndDelete = tc => {


### PR DESCRIPTION
This PR adjusts the comparison used by `cleanupFormattingGap` to match that of other code that compares attribute values, ensuring that `ContentFormat` items are correctly marked as deleted when the `value` is non-primitive.

In v13, testing this was simpler because if a `ContentFormat` was not correctly deleted, `toDelta` would return two separate insertions (one before the `ContentFormat` and one after). Unfortunately, the only way I could find to test this in v14 was to inspect the items directly. I've tried to do so in as flexible a manner as possible to reduce the likelihood of the test failing due to irrelevant changes.

Fixes #776