### PR TITLE
fix stale JSDoc examples after v14 API rename

### DIFF
--- a/src/utils/Snapshot.js
+++ b/src/utils/Snapshot.js
@@ -119,11 +119,11 @@ export const splitSnapshotAffectedStructs = (transaction, snapshot) => {
 /**
  * @example
  *  const ydoc = new Y.Doc({ gc: false })
- *  ydoc.getText().insert(0, 'world!')
+ *  ydoc.get().insert(0, 'world!')
  *  const snapshot = Y.snapshot(ydoc)
- *  ydoc.getText().insert(0, 'hello ')
+ *  ydoc.get().insert(0, 'hello ')
  *  const restored = Y.createDocFromSnapshot(ydoc, snapshot)
- *  assert(restored.getText().toString() === 'world!')
+ *  assert(restored.get().toString() === 'world!')
  *
  * @param {Doc} originDoc
  * @param {Snapshot} snapshot

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -26,18 +26,18 @@ export const generateNewClientId = random.uint53
  *
  * @example
  * const ydoc = new Y.Doc()
- * const map = ydoc.getMap('map')
+ * const map = ydoc.get('map')
  * // Log content when change is triggered
  * map.observe(() => {
  *   console.log('change triggered')
  * })
  * // Each change on the map type triggers a log message:
- * map.set('a', 0) // => "change triggered"
- * map.set('b', 0) // => "change triggered"
+ * map.setAttr('a', 0) // => "change triggered"
+ * map.setAttr('b', 0) // => "change triggered"
  * // When put in a transaction, it will trigger the log after the transaction:
  * ydoc.transact(() => {
- *   map.set('a', 1)
- *   map.set('b', 1)
+ *   map.setAttr('a', 1)
+ *   map.setAttr('b', 1)
  * }) // => "change triggered"
  *
  * @public


### PR DESCRIPTION
## Summary

Two JSDoc `@example` blocks reference Doc/YMap methods that were removed in the v14 API rename:
- `src/utils/Snapshot.js` — `ydoc.getText()` → `ydoc.get()`
- `src/utils/Transaction.js` — `ydoc.getMap('map')` → `ydoc.get('map')`, `map.set(...)` → `map.setAttr(...)`

These examples no longer compile against the current API; anyone copying them from the docs would hit a runtime error.

## Test plan

- [x] `npm test` — all tests pass
- [x] Verified replacements against actual API:
    - `Doc#get(key='', name=null)` at `src/utils/Doc.js:197`
    - `YType#setAttr` at `src/ytype.js:1169`