### PR TITLE
Don't delete nested Yjs types from `oldValue`

### DIFF
--- a/src/structs/ContentType.js
+++ b/src/structs/ContentType.js
@@ -118,7 +118,7 @@ export class ContentType {
     }
     this.type._map.forEach(item => {
       if (!item.deleted) {
-        item.delete(transaction)
+        item.delete(transaction, true)
       } else if (item.id.clock < (transaction.beforeState.get(item.id.client) || 0)) {
         // same as above
         transaction._mergeStructs.push(item)

--- a/src/structs/ContentType.js
+++ b/src/structs/ContentType.js
@@ -106,7 +106,13 @@ export class ContentType {
     let item = this.type._start
     while (item !== null) {
       if (!item.deleted) {
-        item.delete(transaction)
+        if(item != this.type._start) {
+          // Explicitly
+          item.delete(transaction, false)
+        } else {
+          // Implicitly
+          item.delete(transaction, true)
+        }
       } else if (item.id.clock < (transaction.beforeState.get(item.id.client) || 0)) {
         // This will be gc'd later and we want to merge it if possible
         // We try to merge all deleted items after each transaction,

--- a/src/structs/Item.js
+++ b/src/structs/Item.js
@@ -310,6 +310,13 @@ export class Item extends AbstractStruct {
      * @type {number} byte
      */
     this.info = this.content.isCountable() ? binary.BIT2 : 0
+
+    /**
+     * Has meaning only when this.deleted: True if this item was deleted only implicitly,
+     * due to the deletion of a map containing this item under a key; False in all other
+     * kinds of deletion.
+    */
+    this.deletedImplicitly = false;
   }
 
   /**
@@ -612,18 +619,27 @@ export class Item extends AbstractStruct {
    * Mark this Item as deleted.
    *
    * @param {Transaction} transaction
+   * @param {Boolean} implicitly True if this deletion was implicit,
+   * due to the deletion of a map containing this item under a key;
+   * False in all other kinds of deletion.
    */
-  delete (transaction) {
+  delete (transaction, implicitly=false) {
     if (!this.deleted) {
       const parent = /** @type {AbstractType<any>} */ (this.parent)
       // adjust the length of parent
       if (this.countable && this.parentSub === null) {
         parent._length -= this.length
       }
+      if(implicitly) {
+        this.deletedImplicitly = true;
+      }
       this.markDeleted()
       addToDeleteSet(transaction.deleteSet, this.id.client, this.id.clock, this.length)
       addChangedTypeToTransaction(transaction, parent, this.parentSub)
       this.content.delete(transaction)
+    } else if(!implicitly) {
+      // Previously deleted implicitly, but now deleted explicitly.
+      this.deletedImplicitly = false;
     }
   }
 

--- a/src/structs/Item.js
+++ b/src/structs/Item.js
@@ -313,8 +313,8 @@ export class Item extends AbstractStruct {
 
     /**
      * Has meaning only when this.deleted: True if this item was deleted only implicitly,
-     * due to the deletion of a map containing this item under a key; False in all other
-     * kinds of deletion.
+     * due to the deletion of a map containing this item under a key, AND the transaction
+     * for this implicit deletion has not yet happened; False in all other kinds of deletion.
     */
     this.deletedImplicitly = false;
   }

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -4,6 +4,7 @@ import {
   writeDeleteSet,
   DeleteSet,
   sortAndMergeDeleteSet,
+  iterateDeletedStructs,
   getStateVector,
   findIndexSS,
   callEventHandlerListeners,
@@ -276,6 +277,22 @@ const cleanupTransactions = (transactionCleanups, i) => {
        * @type {Array<function():void>}
        */
       const fs = []
+
+      /**
+       * @type {Array<Item>}
+       */
+      const itemsToRemarkAsDeleted = [];
+      iterateDeletedStructs(transaction, ds, (item) => {
+        if(item instanceof Item && item.deletedImplicitly) {
+          // Unmark this implicitly-deleted item so it appears in the oldValue of YMapEvents.
+          item.deleted = false
+          item.deletedImplicitly = false // Allow it to be garbage collected when returned
+
+          // Implicitly-deleted items were still deleted so must be remarked before garbage collection!
+          itemsToRemarkAsDeleted.push(item)
+        }
+      })
+
       // observe events on changed types
       transaction.changed.forEach((subs, itemtype) =>
         fs.push(() => {
@@ -310,6 +327,11 @@ const cleanupTransactions = (transactionCleanups, i) => {
             })
           }
         })
+
+        itemsToRemarkAsDeleted.forEach((item) => {
+          item.deleted = true
+        })
+
         fs.push(() => doc.emit('afterTransaction', [transaction, doc]))
         fs.push(() => {
           if (transaction._needFormattingCleanup) {

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -12,7 +12,7 @@ import {
   generateNewClientId,
   createID,
   cleanupYTextAfterTransaction,
-  UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, ID, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
+  UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
 } from '../internals.js'
 
 import * as map from 'lib0/map'

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -12,7 +12,7 @@ import {
   generateNewClientId,
   createID,
   cleanupYTextAfterTransaction,
-  UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
+  UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, ID, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
 } from '../internals.js'
 
 import * as map from 'lib0/map'
@@ -265,6 +265,24 @@ const cleanupTransactions = (transactionCleanups, i) => {
     const store = doc.store
     const ds = transaction.deleteSet
     const mergeStructs = transaction._mergeStructs
+
+    /**
+     * @type {Array<Item>}
+     */
+    const itemsToRemarkAsDeleted = [];
+    const parentsOfItemsToRemarkAsDeleted = [];
+    iterateDeletedStructs(transaction, ds, (item) => {
+      if(item instanceof Item && item.deletedImplicitly) {
+        // Unmark this implicitly-deleted item so it appears in the oldValue of YMapEvents.
+        item.deleted = false
+        item.deletedImplicitly = false // Allow it to be garbage collected when returned
+
+        // Implicitly-deleted items were still deleted so must be remarked before garbage collection!
+        itemsToRemarkAsDeleted.push(item)
+        parentsOfItemsToRemarkAsDeleted.push(item.parent)
+      }
+    })
+
     try {
       sortAndMergeDeleteSet(ds)
       transaction.afterState = getStateVector(transaction.doc.store)
@@ -277,21 +295,6 @@ const cleanupTransactions = (transactionCleanups, i) => {
        * @type {Array<function():void>}
        */
       const fs = []
-
-      /**
-       * @type {Array<Item>}
-       */
-      const itemsToRemarkAsDeleted = [];
-      iterateDeletedStructs(transaction, ds, (item) => {
-        if(item instanceof Item && item.deletedImplicitly) {
-          // Unmark this implicitly-deleted item so it appears in the oldValue of YMapEvents.
-          item.deleted = false
-          item.deletedImplicitly = false // Allow it to be garbage collected when returned
-
-          // Implicitly-deleted items were still deleted so must be remarked before garbage collection!
-          itemsToRemarkAsDeleted.push(item)
-        }
-      })
 
       // observe events on changed types
       transaction.changed.forEach((subs, itemtype) =>
@@ -328,10 +331,6 @@ const cleanupTransactions = (transactionCleanups, i) => {
           }
         })
 
-        itemsToRemarkAsDeleted.forEach((item) => {
-          item.deleted = true
-        })
-
         fs.push(() => doc.emit('afterTransaction', [transaction, doc]))
         fs.push(() => {
           if (transaction._needFormattingCleanup) {
@@ -339,8 +338,13 @@ const cleanupTransactions = (transactionCleanups, i) => {
           }
         })
       })
+
       callAll(fs, [])
     } finally {
+      itemsToRemarkAsDeleted.forEach((item, i) => {
+        item.deleted = true
+      })
+
       // Replace deleted items with ItemDeleted / GC.
       // This is where content is actually remove from the Yjs Doc.
       if (doc.gc) {

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -269,8 +269,7 @@ const cleanupTransactions = (transactionCleanups, i) => {
     /**
      * @type {Array<Item>}
      */
-    const itemsToRemarkAsDeleted = [];
-    const parentsOfItemsToRemarkAsDeleted = [];
+    const itemsToReMarkAsDeleted = [];
     iterateDeletedStructs(transaction, ds, (item) => {
       if(item instanceof Item && item.deletedImplicitly) {
         // Unmark this implicitly-deleted item so it appears in the oldValue of YMapEvents.
@@ -278,8 +277,7 @@ const cleanupTransactions = (transactionCleanups, i) => {
         item.deletedImplicitly = false // Allow it to be garbage collected when returned
 
         // Implicitly-deleted items were still deleted so must be remarked before garbage collection!
-        itemsToRemarkAsDeleted.push(item)
-        parentsOfItemsToRemarkAsDeleted.push(item.parent)
+        itemsToReMarkAsDeleted.push(item)
       }
     })
 
@@ -341,7 +339,7 @@ const cleanupTransactions = (transactionCleanups, i) => {
 
       callAll(fs, [])
     } finally {
-      itemsToRemarkAsDeleted.forEach((item, i) => {
+      itemsToReMarkAsDeleted.forEach((item, i) => {
         item.deleted = true
       })
 

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -533,33 +533,63 @@ export const testChangeEvent = tc => {
 /**
  * @param {t.TestCase} tc
  */
-export const testNestedMapChangeEvent = tc => {
-  // Unlike the previous test, these tests have the assertion deliberately in the observer functions.
+export const testYmapEventWithYmapOldValue = tc => {
+  // Unlike the previous test, this test has the assertion deliberately in the observer functions.
   // This is because deliberately, the Yjs-shared-type oldValue objects are only ensured to contain their
   // previous states during the observer function itself. After the observer has finished, for example,
   // garbage collection deletes the elements from the deleted nmap, before deleting the whole map itself
   // from the document.
+
+  // This test won't fail if observe or observeDeep aren't ever called, but checking observe and
+  // observeDeep get called is other tests' responsibility.
   const { map0, users } = init(tc, { users: 2 })
   const nmap = new Y.Map()
   const nnmap = new Y.Map()
 
   const setObserver = (/** @type {any} */e) => {
+    console.log("Set observer called")
     const keyChange = e.changes.keys.get('map')
     t.assert(e.changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
   }
+  const setDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Set deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        setObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
 
   map0.observe(setObserver)
+  map0.observeDeep(setDeepObserver)
   map0.set('map', nmap)
   map0.unobserve(setObserver)
+  map0.unobserveDeep(setDeepObserver)
 
   const transactObserver = (/** @type {any} */e) => {
+    console.log("Transact observer called")
     const keyChange = e.changes.keys.get('map')
     t.assert(e.changes !== null && keyChange.action === 'delete' &&
     !keyChange.oldValue.has('x') && keyChange.oldValue.get('map') == nnmap
     && keyChange.oldValue.get('map').get('z') == 2 && keyChange.oldValue.get('y') == 1)
   }
+  const transactDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Transact deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        transactObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
 
   map0.observe(transactObserver)
+  map0.observeDeep(transactDeepObserver)
   users[0].transact(() => {
     nmap.set('x', 0)
     nmap.set('map', nnmap)
@@ -570,6 +600,179 @@ export const testNestedMapChangeEvent = tc => {
     map0.delete('map')
   })
   map0.unobserve(transactObserver)
+  map0.unobserveDeep(transactDeepObserver)
+
+  compare(users)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testYmapEventWithYtextOldValue = tc => {
+  // Like the previous test, this test has the assertion deliberately in the observer functions.
+  const { map0, users } = init(tc, { users: 2 })
+
+  const ytext0 = new Y.Text()
+  ytext0.insert(0, 'Hello')
+  const ytext1 = new Y.Text()
+
+  const setObserver = (/** @type {any} */e) => {
+    console.log("Set observer called")
+    const keyChange = e.changes.keys.get('text')
+    t.assert(e.changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+  }
+  const setDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Set deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        setObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(setObserver)
+  map0.observeDeep(setDeepObserver)
+  map0.set('text', ytext0)
+  map0.unobserve(setObserver)
+  map0.unobserveDeep(setDeepObserver)
+
+  const updateObserver = (/** @type {any} */e) => {
+    console.log("Update observer called")
+    const keyChange = e.changes.keys.get('text')
+    console.log(keyChange.oldValue === ytext0, keyChange.oldValue._item.content)
+    t.assert(e.changes !== null && keyChange.action === 'update' && keyChange.oldValue === ytext0 && keyChange.oldValue.toString() == 'Hello')
+  }
+  const updateDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Update deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        updateObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(updateObserver)
+  map0.observeDeep(updateDeepObserver)
+  map0.set('text', ytext1)
+  map0.unobserve(updateObserver)
+  map0.unobserveDeep(updateDeepObserver)
+
+  ytext1.insert(0, 'World')
+
+  const deleteObserver = (/** @type {any} */e) => {
+    console.log("Delete observer called")
+    const keyChange = e.changes.keys.get('text')
+    t.assert(e.changes !== null && keyChange.action === 'delete' && keyChange.oldValue === ytext1 && keyChange.oldValue.toString() == 'World')
+  }
+  const deleteDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Delete deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        deleteObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(deleteObserver)
+  map0.observeDeep(deleteDeepObserver)
+  map0.delete('text')
+  map0.unobserve(deleteObserver)
+  map0.unobserveDeep(deleteDeepObserver)
+
+  compare(users)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testYmapEventWithYarrayOldValue = tc => {
+  // Like the previous test, this test has the assertion deliberately in the observer functions.
+  const { map0, users } = init(tc, { users: 2 })
+
+  const yarray0 = new Y.Array()
+  yarray0.insert(0, [1,2,3])
+  const yarray1 = new Y.Array()
+
+  const setObserver = (/** @type {any} */e) => {
+    console.log("Set observer called", e)
+    const keyChange = e.changes.keys.get('arr')
+    t.assert(e.changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+  }
+  const setDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Set deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        setObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(setObserver)
+  map0.observeDeep(setDeepObserver)
+  map0.set('arr', yarray0)
+  map0.unobserve(setObserver)
+  map0.unobserveDeep(setDeepObserver)
+
+  const updateObserver = (/** @type {any} */e) => {
+    console.log("Update observer called")
+    const keyChange = e.changes.keys.get('arr')
+    console.log(keyChange.oldValue === yarray0, keyChange.oldValue._item.content)
+    t.assert(e.changes !== null && keyChange.action === 'update' && keyChange.oldValue === yarray0 && keyChange.oldValue.get(0) == 1 && keyChange.oldValue.get(1) == 2 && keyChange.oldValue.get(2) == 3)
+  }
+  const updateDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Update deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        updateObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(updateObserver)
+  map0.observeDeep(updateDeepObserver)
+  map0.set('arr', yarray1)
+  map0.unobserve(updateObserver)
+  map0.unobserveDeep(updateDeepObserver)
+
+  yarray1.insert(0, [3, 2, 1])
+
+  const deleteObserver = (/** @type {any} */e) => {
+    console.log("Delete observer called")
+    const keyChange = e.changes.keys.get('arr')
+    t.assert(e.changes !== null && keyChange.action === 'delete' && keyChange.oldValue === yarray1 && keyChange.oldValue.get(0) == 3 && keyChange.oldValue.get(1) == 2 && keyChange.oldValue.get(2) == 1)
+  }
+  const deleteDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Delete deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        deleteObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(deleteObserver)
+  map0.observeDeep(deleteDeepObserver)
+  map0.delete('arr')
+  map0.unobserve(deleteObserver)
+  map0.unobserveDeep(deleteDeepObserver)
 
   compare(users)
 }

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -531,6 +531,51 @@ export const testChangeEvent = tc => {
 }
 
 /**
+ * @param {t.TestCase} tc
+ */
+export const testNestedMapChangeEvent = tc => {
+  const { map0, users } = init(tc, { users: 2 })
+  const nmap = new Y.Map()
+  const nnmap = new Y.Map()
+
+  /**
+   * @type {any}
+   */
+  let changes = null
+  /**
+   * @type {any}
+   */
+  let keyChange = null
+  map0.observe(e => {
+    changes = e.changes
+  })
+  map0.set('map', nmap)
+  keyChange = changes.keys.get('map')
+  t.assert(changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+
+  users[0].transact(() => {
+    nmap.set('x', 0)
+    nmap.set('map', nnmap)
+    nmap.set('y', 1)
+    nnmap.set('z', 2)
+
+    nmap.delete('x')
+    map0.delete('map')
+  })
+  keyChange = changes.keys.get('map')
+
+  console.log(changes !== null)
+  console.log(keyChange.action === 'delete')
+  console.log(!keyChange.oldValue.has('x'))
+  console.log(keyChange.oldValue.get('map').get('z') == 2)
+  console.log(keyChange.oldValue.get('y') == 1)
+
+  t.assert(changes !== null && keyChange.action === 'delete' &&
+  !keyChange.oldValue.has('x') && keyChange.oldValue.get('map') == nnmap && keyChange.oldValue.get('map').get('z') == 2 && keyChange.oldValue.get('y') == 1)
+  compare(users)
+}
+
+/**
  * @param {t.TestCase} _tc
  */
 export const testYmapEventExceptionsShouldCompleteTransaction = _tc => {

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -534,25 +534,32 @@ export const testChangeEvent = tc => {
  * @param {t.TestCase} tc
  */
 export const testNestedMapChangeEvent = tc => {
+  // Unlike the previous test, these tests have the assertion deliberately in the observer functions.
+  // This is because deliberately, the Yjs-shared-type oldValue objects are only ensured to contain their
+  // previous states during the observer function itself. After the observer has finished, for example,
+  // garbage collection deletes the elements from the deleted nmap, before deleting the whole map itself
+  // from the document.
   const { map0, users } = init(tc, { users: 2 })
   const nmap = new Y.Map()
   const nnmap = new Y.Map()
 
-  /**
-   * @type {any}
-   */
-  let changes = null
-  /**
-   * @type {any}
-   */
-  let keyChange = null
-  map0.observe(e => {
-    changes = e.changes
-  })
-  map0.set('map', nmap)
-  keyChange = changes.keys.get('map')
-  t.assert(changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+  const setObserver = (/** @type {any} */e) => {
+    const keyChange = e.changes.keys.get('map')
+    t.assert(e.changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+  }
 
+  map0.observe(setObserver)
+  map0.set('map', nmap)
+  map0.unobserve(setObserver)
+
+  const transactObserver = (/** @type {any} */e) => {
+    const keyChange = e.changes.keys.get('map')
+    t.assert(e.changes !== null && keyChange.action === 'delete' &&
+    !keyChange.oldValue.has('x') && keyChange.oldValue.get('map') == nnmap
+    && keyChange.oldValue.get('map').get('z') == 2 && keyChange.oldValue.get('y') == 1)
+  }
+
+  map0.observe(transactObserver)
   users[0].transact(() => {
     nmap.set('x', 0)
     nmap.set('map', nnmap)
@@ -562,16 +569,8 @@ export const testNestedMapChangeEvent = tc => {
     nmap.delete('x')
     map0.delete('map')
   })
-  keyChange = changes.keys.get('map')
+  map0.unobserve(transactObserver)
 
-  console.log(changes !== null)
-  console.log(keyChange.action === 'delete')
-  console.log(!keyChange.oldValue.has('x'))
-  console.log(keyChange.oldValue.get('map').get('z') == 2)
-  console.log(keyChange.oldValue.get('y') == 1)
-
-  t.assert(changes !== null && keyChange.action === 'delete' &&
-  !keyChange.oldValue.has('x') && keyChange.oldValue.get('map') == nnmap && keyChange.oldValue.get('map').get('z') == 2 && keyChange.oldValue.get('y') == 1)
   compare(users)
 }
 


### PR DESCRIPTION
Firstly, I know this is a late time to send the bug, for Europeans. Don't feel pressured to review it too quickly or soon; my code likely contains bugs (though it passes all existing tests on `npm run test`, plus my new tests).

(TL;DR look at the code, the bullet points below "purpose", and my last few paragraphs.)

## Purpose
Fixes #786, letting y-shared-type  (`Y.Map`, `Y.Text`, and `Y.Array` have been tested) **children of `Y.Map` elements show up in `YMapEvent.changes.keys.get("name").oldValue`** during `observe` and `observeDeep` callbacks. Notable points include:
* No cloning occurs, so reference comparisons still work (this is in the test suite): `oldValue === ytext1` where `yext1` was defined as `const ytext1 = new Y.Text() ; map0.set('text', ytext1)`
* As I believe (but not have checked) occurred previously, taking the deleted `oldValue` or one of its child y-shared-types and, without cloning it, placing it elsewhere in the document does not work. That old value is marked as deleted (or for the case of child items will be deleted immediately after the observe callback, at the end of the transaction) so will be garbage-collected and not end up where you moved it in the long-term. This is easy to solve by cloning the y-type before placing it elsewhere in the document.
* Similarly, placing the `oldValue` in a variable during the observe callback without cloning it, and accessing the variable later outside the callback and after the transaction that deleted it, will give an empty type. This is similarly easy to solve by cloning the y-type in the observer function.

Would you be able to put these points in the documentation for version 13?

## Approach
My method does not change when the initial markDeletes happen; rather it temporarily removes the relevant delete marks while observer callbacks happen, and adds them back before the transaction ends and the garbage collector kicks in. I think the more drastic change of adjusting when initial markDeletes happen may prevent the need for the caveats listed above, but would also be a breaking change, and probably cause different unintuitive points.

Please let me know if you have any questions or requests about my code, tests, etc.

## Status
As of commit `a9052a4`, the tests pass (for `YMap`, `YText`, and `YArray` children of `YMap`s).

***I have not yet written any tests for xml-related children of `YMap`s, or any children of ~~`YArray` or~~ xml-related types, although this fix is general enough to probably affect them too. Should I write those tests?***

Thanks for your time!