### PR TITLE
Fix nested YMap value in YMap event's oldValue

### DIFF
--- a/src/types/AbstractType.js
+++ b/src/types/AbstractType.js
@@ -10,6 +10,7 @@ import {
   ContentAny,
   ContentBinary,
   getItemCleanStart,
+  rollForwardToCurrentValue,
   ContentDoc, YText, YArray, UpdateEncoderV1, UpdateEncoderV2, Doc, Snapshot, Transaction, EventHandler, YEvent, Item, // eslint-disable-line
 } from '../internals.js'
 
@@ -252,6 +253,7 @@ export const callTypeObservers = (type, transaction, event) => {
     type = /** @type {AbstractType<any>} */ (type._item.parent)
   }
   callEventHandlerListeners(changedType._eH, event, transaction)
+  if(event instanceof YEvent) rollForwardToCurrentValue(event, type)
 }
 
 /**

--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -11,6 +11,7 @@ import {
   generateNewClientId,
   createID,
   cleanupYTextAfterTransaction,
+  rollForwardToCurrentValue,
   UpdateEncoderV1, UpdateEncoderV2, GC, StructStore, AbstractType, AbstractStruct, YEvent, Doc // eslint-disable-line
 } from '../internals.js'
 
@@ -307,6 +308,9 @@ const cleanupTransactions = (transactionCleanups, i) => {
               // We don't need to check for events.length
               // because we know it has at least one element
               callEventHandlerListeners(type._dEH, events, transaction)
+              events.forEach(event => {
+                if(event instanceof YEvent) rollForwardToCurrentValue(event, type)
+              })
             })
           }
         })

--- a/src/utils/YEvent.js
+++ b/src/utils/YEvent.js
@@ -221,7 +221,6 @@ export class YEvent {
           const actionAndOldItem = getActionAndOldItem(this, item)
           if(actionAndOldItem === undefined) return // nop
           if(actionAndOldItem.oldItem === undefined) {
-            // why TF TODO delete - item.deleted = true
             keys.set(key, { action: actionAndOldItem.action, oldValue: undefined })
           } else {
             const oldValue = array.last(actionAndOldItem.oldItem.content.getContent())

--- a/src/utils/YEvent.js
+++ b/src/utils/YEvent.js
@@ -1,6 +1,6 @@
 import {
   isDeleted,
-  Item, AbstractType, Transaction, AbstractStruct // eslint-disable-line
+  Item, AbstractType, ContentType, Transaction, AbstractStruct // eslint-disable-line
 } from '../internals.js'
 
 import * as set from 'lib0/set'
@@ -8,6 +8,122 @@ import * as array from 'lib0/array'
 import * as error from 'lib0/error'
 
 const errorComputeChanges = 'You must not compute changes after the event-handler fired.'
+
+
+/**
+ * Change the object content in-place to its state before the transaction (currently incomplete:
+ * nested YMaps are rolled back to pre-transaction state but no other shared types in the value are).
+ *
+ * @param {YEvent<AbstractType<any>>} yevent
+ * @param {any} obj
+ *
+ * @private
+ * @function
+ */
+const rollBackToOldValue = (yevent, obj) => {
+  yevent._rolledBack = true
+
+  if(obj instanceof AbstractType) {
+    obj._map.forEach((item, key) => {
+      const actionAndOldItem = getActionAndOldItem(yevent, item)
+      if(actionAndOldItem !== undefined && actionAndOldItem.oldItem !== undefined) {
+        rollBackToOldValue(yevent, array.last(actionAndOldItem.oldItem.content.getContent()))
+        if(yevent.deletes(item)) {
+          actionAndOldItem.oldItem.deleted = false // TODO: check
+        }
+        obj._map.set(key, actionAndOldItem.oldItem)
+      }
+    })
+  }
+}
+
+/**
+ * After calling _rollBackToOldValue, call this to revert the status of a values nested shared types
+ * to the end of the transaction this event is associated with.
+ *
+ * @param {YEvent<AbstractType<any>>} yevent
+ * @param {any} obj
+ */
+export const rollForwardToCurrentValue = (yevent, obj) => {
+  if(!yevent._rolledBack) {
+    return
+  }
+
+  if(obj instanceof AbstractType) {
+    obj._map.forEach((item, key) => {
+      while(item.right !== null) {
+        item.deleted = true // TODO: check
+        item = item.right
+      }
+      if(yevent.deletes(item)) {
+        item.deleted = true // TODO: check
+      } else if(yevent.adds(item)) {
+        item.deleted = false
+      }
+
+      if(item.content instanceof ContentType) {
+        rollForwardToCurrentValue(yevent, item.content.getContent()[0]) // Don't construct new
+      }
+      obj._map.set(key, item)
+    })
+  }
+
+  // Force keys to be calculated next time it is accessed, so it is rolled back again
+  yevent._keys = null
+  yevent._changes = null
+}
+
+/**
+ * @param {YEvent<AbstractType<any>>} yevent
+ * @param {Item} item The item from a map's value (a linked list in which
+ * only the last element is current).
+ * @returns {{action: 'add' | 'update' | 'delete', oldItem: Item | undefined}
+ * | undefined} The action which occurred during this event's transaction, and
+ * the value of the item before the transaction (currently nested YMaps of YMaps
+ * are also rolled back to pre-transaction state but no other shared types are).
+ *
+ * @private
+ * @function
+ */
+const getActionAndOldItem = (yevent, item) => {
+  /**
+   * @type {'delete' | 'add' | 'update'}
+   */
+  let action
+  /** @type {Item | undefined} */let oldItem
+
+  if (yevent.adds(item)) {
+    let prev = item.left
+    while (prev !== null && yevent.adds(prev)) {
+      prev = prev.left
+    }
+    if (yevent.deletes(item)) {
+      if (prev !== null && yevent.deletes(prev)) {
+        action = 'delete'
+        oldItem = prev
+      } else {
+        return
+      }
+    } else {
+      if (prev !== null && yevent.deletes(prev)) {
+        action = 'update'
+        oldItem = prev
+      } else {
+        action = 'add'
+        oldItem = undefined
+      }
+    }
+  } else {
+    if (yevent.deletes(item)) {
+      action = 'delete'
+      oldItem = item
+    } else {
+      return // nop
+    }
+  }
+  return { action, oldItem }
+}
+
 
 /**
  * @template {AbstractType<any>} T
@@ -50,6 +166,13 @@ export class YEvent {
      * @type {Array<string|number>|null}
      */
     this._path = null
+
+
+    /**
+     * @type {Boolean} Whether _rollBackToOldValue has been called.
+     *
+     */
+    this._rolledBack = false
   }
 
   /**
@@ -95,41 +218,16 @@ export class YEvent {
       changed.forEach(key => {
         if (key !== null) {
           const item = /** @type {Item} */ (target._map.get(key))
-          /**
-           * @type {'delete' | 'add' | 'update'}
-           */
-          let action
-          let oldValue
-          if (this.adds(item)) {
-            let prev = item.left
-            while (prev !== null && this.adds(prev)) {
-              prev = prev.left
-            }
-            if (this.deletes(item)) {
-              if (prev !== null && this.deletes(prev)) {
-                action = 'delete'
-                oldValue = array.last(prev.content.getContent())
-              } else {
-                return
-              }
-            } else {
-              if (prev !== null && this.deletes(prev)) {
-                action = 'update'
-                oldValue = array.last(prev.content.getContent())
-              } else {
-                action = 'add'
-                oldValue = undefined
-              }
-            }
+          const actionAndOldItem = getActionAndOldItem(this, item)
+          if(actionAndOldItem === undefined) return // nop
+          if(actionAndOldItem.oldItem === undefined) {
+            // why TF TODO delete - item.deleted = true
+            keys.set(key, { action: actionAndOldItem.action, oldValue: undefined })
           } else {
-            if (this.deletes(item)) {
-              action = 'delete'
-              oldValue = array.last(/** @type {Item} */ item.content.getContent())
-            } else {
-              return // nop
-            }
+            const oldValue = array.last(actionAndOldItem.oldItem.content.getContent())
+            rollBackToOldValue(this, oldValue)
+            keys.set(key, { action: actionAndOldItem.action, oldValue })
           }
-          keys.set(key, { action, oldValue })
         }
       })
       this._keys = keys

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -453,7 +453,7 @@ export const testThrowsAddAndUpdateAndDeleteEvents = tc => {
   map0.delete('stuff')
   compareEvent(event, {
     keysChanged: new Set(['stuff']),
-    target: map0
+               target: map0
   })
   compare(users)
 }
@@ -477,7 +477,7 @@ export const testThrowsDeleteEventsOnClear = tc => {
   map0.clear()
   compareEvent(event, {
     keysChanged: new Set(['stuff', 'otherstuff']),
-    target: map0
+               target: map0
   })
   compare(users)
 }
@@ -527,6 +527,82 @@ export const testChangeEvent = tc => {
   })
   keyChange = changes.keys.get('d')
   t.assert(changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+  compare(users)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testYmapEventWithYmapOldValue = tc => {
+  // Unlike the previous test, this test has the assertion deliberately in the observer functions.
+  // This is because deliberately, the Yjs-shared-type oldValue objects are only ensured to contain their
+  // previous states during the observer function itself. After the observer has finished, for example,
+  // garbage collection deletes the elements from the deleted nmap, before deleting the whole map itself
+  // from the document.
+
+  // This test won't fail if observe or observeDeep aren't ever called, but checking observe and
+  // observeDeep get called is other tests' responsibility.
+  const { map0, users } = init(tc, { users: 2 })
+  const nmap = new Y.Map()
+  const nnmap = new Y.Map()
+
+  const setObserver = (/** @type {any} */e) => {
+    console.log("Set observer called")
+    const keyChange = e.changes.keys.get('map')
+    t.assert(e.changes !== null && keyChange.action === 'add' && keyChange.oldValue === undefined)
+  }
+  const setDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Set deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        setObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  map0.observe(setObserver)
+  map0.observeDeep(setDeepObserver)
+  map0.set('map', nmap)
+  map0.unobserve(setObserver)
+  map0.unobserveDeep(setDeepObserver)
+
+  const transactObserver = (/** @type {any} */e) => {
+    console.log("Transact observer called")
+    const keyChange = e.changes.keys.get('map')
+    t.assert(e.changes !== null && keyChange.action === 'delete' &&
+    !keyChange.oldValue.has('x') && keyChange.oldValue.get('map') == nnmap
+    && keyChange.oldValue.get('map').get('z') == 2 && !keyChange.oldValue.has('y'))
+  }
+  const transactDeepObserver = (/** @type {any} */events, /** @type {any} */transaction) => {
+    console.log("Transact deep observer called")
+    let hasEventWithMap0Target = false
+    for(const evt of events) {
+      if(evt.target === map0) {
+        transactObserver(evt)
+        hasEventWithMap0Target = true
+      }
+    }
+    t.assert(hasEventWithMap0Target)
+  }
+
+  nnmap.set('z', 2)
+  nmap.set('map', nnmap)
+
+  map0.observe(transactObserver)
+  map0.observeDeep(transactDeepObserver)
+  users[0].transact(() => {
+    nmap.set('x', 0)
+    nmap.set('y', 1)
+
+    nmap.delete('x')
+    map0.delete('map')
+  })
+  map0.unobserve(transactObserver)
+  map0.unobserveDeep(transactDeepObserver)
+
   compare(users)
 }
 


### PR DESCRIPTION
Thank you Kevin for your patience and the team for your steadfast maintenance of YJS!

This is a fix for (some of) #786, taking into account  both of Kevin Jahns' suggestions in #787, and fixing the mistake of missing pre-transaction state I realised I made and documented in that PR #787.

The method is still roll-back of the `oldValue`'s nested YMaps' deleted marks, this time into a pre-transaction state. To reduce performance issues, this only runs when a `YEvent.changed` getter is called, traversing the `oldValue`s and no other part of the document. Similarly, roll-forward only runs once roll-back has previously occurred.

None of this affects or adds a new field to the Item struct. Rather, it re-uses code used to calculate the initial `oldValue`, to detect what changes happened in the transaction.

## Important

The current state of the pull request only fixes #786 for `YMap`s inside `YMap`s (that's all I need for my use-case). Fixing #786 for YArrays and  YTexts in YMaps, or shared types in YArrays, and XML-related shared types, requires slightly tedious work needing care, for someone still rather unfamiliar with YJs' codebase like me (especially given this will be replaced with the v14 rewrite soon). However I believe it's implementable using the same method: Inspect the YText.delta and YEvent.changes rather than the YEvent.keys code, and incorporate manipulating the list-like structure under `_item` in roll-back and roll-forward along with the `_map` operations. Then, add more tests, including perhaps my YArray-in-YMap and YText-in-YMap tests from #787.

## Tests

In the state of this PR, `npm run test` gives "All tests successful!".