### PR TITLE
docs(readme): add Deln0r/ygo to the Ports list

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ language bindings to other languages
   * [ypy](https://github.com/y-crdt/ypy) - Python binding (deprecated, use pycrdt)
 * [ycs](https://github.com/yjs/ycs) - .Net compatible C# implementation.
 * [ygo](https://github.com/reearth/ygo) - Go implementation.
+* [ygo (Deln0r/ygo)](https://github.com/Deln0r/ygo) - Go implementation.
 
 ## Getting Started
 


### PR DESCRIPTION
Follow-up to yjs/docs#80, which you merged to add Deln0r/ygo to the docs ports page. The main README's Ports section still lists only reearth's port under "ygo", so this adds mine alongside it, disambiguated the same way the docs page does (ygo (Deln0r/ygo)).

Deln0r/ygo is a pure-Go port, byte-for-byte wire-compatible with the JS reference in V1 and V2, verified bidirectionally by cross-language fixtures. One line, mirroring the existing entry's format. Happy to reword or drop it if you would rather keep a single Go entry in the README.
