### PR TITLE
fix: deep event currentTarget when multiple deep observers are attached (closes #768)

### DIFF
--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -294,16 +294,20 @@ const cleanupTransactions = (transactionCleanups, i) => {
               .filter(event =>
                 event.target._item === null || !event.target._item.deleted
               )
-            events
-              .forEach(event => {
+            // Defer `event.currentTarget` mutation and the call to deep event
+            // listeners so that an error in one observer does not prevent the
+            // next one from firing, and so that the same `YEvent` instance shared
+            // by multiple parent types (added in `callTypeObservers`) ends up
+            // with the correct `currentTarget` for each observer. See #768.
+            fs.push(() => {
+              events.forEach(event => {
                 event.currentTarget = type
                 // path is relative to the current target
                 event._path = null
               })
-            // sort events by path length so that top-level events are fired first.
-            events
-              .sort((event1, event2) => event1.path.length - event2.path.length)
-            fs.push(() => {
+              // sort events by path length so that top-level events are fired first.
+              events
+                .sort((event1, event2) => event1.path.length - event2.path.length)
               // We don't need to check for events.length
               // because we know it has at least one element
               callEventHandlerListeners(type._dEH, events, transaction)

--- a/tests/y-map.tests.js
+++ b/tests/y-map.tests.js
@@ -413,6 +413,81 @@ export const testPathsOfSiblingEvents = tc => {
   compare(users)
 }
 
+/**
+ * Multiple deep observers attached to a parent and one of its children must
+ * each see the same change with a path relative to their own `currentTarget`.
+ *
+ * Regression test for issue #768: in v13.6.29, deep event handler calls were
+ * deferred via `callAll`. Because the same `YEvent` instance is added to
+ * `changedParentTypes` for every ancestor type that has a deep observer, the
+ * `event.currentTarget` mutation that runs inside the deep-event setup loop
+ * was being overwritten by the next iteration before the previously-prepared
+ * handler was called, so observers on the outer type saw the inner type as
+ * `currentTarget` and an empty `path`.
+ *
+ * @param {t.TestCase} tc
+ */
+export const testDeepObserveMultipleAncestors = tc => {
+  const doc = new Y.Doc()
+  const a = doc.getMap('a')
+  a.set('b', new Y.Map())
+  a.set('c', new Y.Map())
+  /**
+   * @type {Array<{ currentTarget: 'a' | 'a.c', path: Array<string|number> }>}
+   */
+  const aObserver = []
+  a.observeDeep(events => {
+    events.forEach(event => {
+      aObserver.push({
+        currentTarget: /** @type {'a' | 'a.c'} */ (event.currentTarget === a ? 'a' : 'a.c'),
+        path: event.path
+      })
+    })
+  })
+  // First transact — only the `a` deep observer exists. Both `b.foo` and
+  // `c.foo` should be reported with the path relative to `a`.
+  doc.transact(() => {
+    a.get('b').set('foo', 'bar')
+    a.get('c').set('foo', 'bar')
+  })
+  t.compare(aObserver, [
+    { currentTarget: 'a', path: ['b'] },
+    { currentTarget: 'a', path: ['c'] }
+  ])
+  // Add a second deep observer on `a.c`.
+  /**
+   * @type {Array<{ currentTarget: 'a' | 'a.c', path: Array<string|number> }>}
+   */
+  const cObserver = []
+  /**
+   * @param {Array<Y.YEvent<Y.AbstractType<any>>>} events
+   */
+  const collectCObserver = events => {
+    events.forEach(event => {
+      cObserver.push({
+        currentTarget: /** @type {'a' | 'a.c'} */ (event.currentTarget === a ? 'a' : 'a.c'),
+        path: event.path
+      })
+    })
+  }
+  a.get('c').observeDeep(collectCObserver)
+  // Second transact — both observers should fire and each must see its own
+  // `currentTarget` and a path relative to it.
+  doc.transact(() => {
+    a.get('b').set('foo', 'baz')
+    a.get('c').set('foo', 'baz')
+  })
+  t.compare(aObserver.slice(2), [
+    { currentTarget: 'a', path: ['b'] },
+    { currentTarget: 'a', path: ['c'] }
+  ])
+  // The `a.c` observer sees only the change inside `c`, with a path relative
+  // to `a.c` (which is `[]`).
+  t.compare(cObserver, [
+    { currentTarget: 'a.c', path: [] }
+  ])
+}
+
 // TODO: Test events in Y.Map
 /**
  * @param {Object<string,any>} is


### PR DESCRIPTION
## Summary
Fix deep event `currentTarget` (and therefore `event.path`) when multiple `observeDeep` handlers are attached to a type and to one of its ancestors.

## Problem
Since v13.6.29 (commit cff7de11, "catch errors in deep event handlers"), the deep event handler invocations are deferred via `callAll` so that an error in one observer does not stop the next one from firing. That part is correct.

However, the same `YEvent` instance is added to `transaction.changedParentTypes` for every ancestor type that has a deep observer (see `callTypeObservers` in `src/types/AbstractType.js`). The `event.currentTarget = type` mutation was being run inside the deep-event setup loop **before** the deferred call, so by the time the previously-prepared outer-type handler was called, `currentTarget` had already been overwritten by the next iteration. The outer observer then saw the inner type as its `currentTarget` and an empty `event.path`.

Reproduction from issue #768 (run against v13.6.30):

```js
import * as Y from "yjs";

const ydoc = new Y.Doc();
ydoc.getMap("a");
ydoc.get("a").set("b", new Y.Map());
ydoc.get("a").set("c", new Y.Map());

ydoc.getMap("a").observeDeep(events => {
  events.forEach(event => {
    console.log("event path:", event.path, "currentTarget is a?", event.currentTarget === ydoc.get("a"));
  });
});

ydoc.transact(() => {
  ydoc.get("a").get("b").set("foo", "bar");
  ydoc.get("a").get("c").set("foo", "bar");
});

ydoc.get("a").get("c").observeDeep(() => {});

ydoc.transact(() => {
  ydoc.get("a").get("b").set("foo", "bar");
  ydoc.get("a").get("c").set("foo", "bar");
  // BEFORE the fix, the "a" deep observer would see the "c" change with
  // event.path === [] and event.currentTarget === ydoc.get("a").get("c")
});
```

**Expected**: `event.currentTarget` should always be the type originally observed so that `event.path` is also relative to the type originally observed.
**Actual (before fix)**: when a second deep observer is attached to `a.c`, the outer `a` observer's `currentTarget` becomes `a.c` and `path` is `[]` for the change to `a.c`.

## Solution
Defer the `event.currentTarget = type` mutation and the path-based sort into the same deferred step that calls the listeners. Each observer now sets `currentTarget` immediately before its own handler runs, so:

- error handling from cff7de11 is preserved (errors still do not stop other observers)
- each observer sees its own `currentTarget` and a `path` relative to it

## Changes Made
- `src/utils/Transaction.js`: moved `event.currentTarget = type`, `event._path = null`, and the path-length sort into the same deferred function that calls `callEventHandlerListeners`. The outer `forEach` now only filters events and pushes the deferred handler.
- `tests/y-map.tests.js`: added `testDeepObserveMultipleAncestors` regression test covering the exact scenario from #768 (first transact with a single deep observer, second transact after a nested deep observer is added).

## Testing
- New regression test `testDeepObserveMultipleAncestors` passes against this branch.
- The throwing-event-handler test (`testYmapEventExceptionsShouldCompleteTransaction`) still passes, so the error-catching behavior from cff7de11 is preserved.
- The pre-existing flakiness in the random tests (`testRepeatGeneratingYarray*`, `testNestedObserverEvents`, `testYmapEventHasCorrectValueWhenSettingAPrimitive*`) is unrelated to this change — they fail identically on `v13` before the patch.
- Lint (`npm run lint`): ✅ 0 errors
- TypeScript (`tsc --skipLibCheck`): ✅ passes

## Checklist
- [x] Tests pass locally
- [x] Lint passes
- [x] Code follows repo style
- [x] Documentation updated if needed (no public API change)
- [x] No console.log or debug code left
- [x] No unrelated changes

Closes #768
