### PR TITLE
fix: finish transaction cleanup when a doc event handler throws

### DIFF
--- a/src/utils/Transaction.js
+++ b/src/utils/Transaction.js
@@ -312,41 +312,57 @@ const cleanupTransactions = (transactionCleanups, i) => {
         doc.clientID = generateNewClientId()
       }
       // @todo Merge all the transactions into one and provide send the data as a single update message
-      doc.emit('afterTransactionCleanup', [transaction, doc])
-      if (doc._observers.has('update')) {
-        const encoder = new UpdateEncoderV1()
-        const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
-        if (hasContent) {
-          doc.emit('update', [encoder.toUint8Array(), transaction.origin, doc, transaction])
-        }
-      }
-      if (doc._observers.has('updateV2')) {
-        const encoder = new UpdateEncoderV2()
-        const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
-        if (hasContent) {
-          doc.emit('updateV2', [encoder.toUint8Array(), transaction.origin, doc, transaction])
-        }
-      }
-      const { subdocsAdded, subdocsLoaded, subdocsRemoved } = transaction
-      if (subdocsAdded.size > 0 || subdocsRemoved.size > 0 || subdocsLoaded.size > 0) {
-        subdocsAdded.forEach(subdoc => {
-          subdoc.clientID = doc.clientID
-          if (subdoc.collectionid == null) {
-            subdoc.collectionid = doc.collectionid
+      /**
+       * Each callback is called even if the other ones throw errors.
+       *
+       * @type {Array<function():void>}
+       */
+      const afterFs = []
+      afterFs.push(() => {
+        doc.emit('afterTransactionCleanup', [transaction, doc])
+      })
+      afterFs.push(() => {
+        if (doc._observers.has('update')) {
+          const encoder = new UpdateEncoderV1()
+          const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
+          if (hasContent) {
+            doc.emit('update', [encoder.toUint8Array(), transaction.origin, doc, transaction])
           }
-          doc.subdocs.add(subdoc)
-        })
-        subdocsRemoved.forEach(subdoc => doc.subdocs.delete(subdoc))
-        doc.emit('subdocs', [{ loaded: subdocsLoaded, added: subdocsAdded, removed: subdocsRemoved }, doc, transaction])
-        subdocsRemoved.forEach(subdoc => subdoc.destroy())
-      }
-
-      if (transactionCleanups.length <= i + 1) {
-        doc._transactionCleanups = []
-        doc.emit('afterAllTransactions', [doc, transactionCleanups])
-      } else {
-        cleanupTransactions(transactionCleanups, i + 1)
-      }
+        }
+      })
+      afterFs.push(() => {
+        if (doc._observers.has('updateV2')) {
+          const encoder = new UpdateEncoderV2()
+          const hasContent = writeUpdateMessageFromTransaction(encoder, transaction)
+          if (hasContent) {
+            doc.emit('updateV2', [encoder.toUint8Array(), transaction.origin, doc, transaction])
+          }
+        }
+      })
+      afterFs.push(() => {
+        const { subdocsAdded, subdocsLoaded, subdocsRemoved } = transaction
+        if (subdocsAdded.size > 0 || subdocsRemoved.size > 0 || subdocsLoaded.size > 0) {
+          subdocsAdded.forEach(subdoc => {
+            subdoc.clientID = doc.clientID
+            if (subdoc.collectionid == null) {
+              subdoc.collectionid = doc.collectionid
+            }
+            doc.subdocs.add(subdoc)
+          })
+          subdocsRemoved.forEach(subdoc => doc.subdocs.delete(subdoc))
+          doc.emit('subdocs', [{ loaded: subdocsLoaded, added: subdocsAdded, removed: subdocsRemoved }, doc, transaction])
+          subdocsRemoved.forEach(subdoc => subdoc.destroy())
+        }
+      })
+      afterFs.push(() => {
+        if (transactionCleanups.length <= i + 1) {
+          doc._transactionCleanups = []
+          doc.emit('afterAllTransactions', [doc, transactionCleanups])
+        } else {
+          cleanupTransactions(transactionCleanups, i + 1)
+        }
+      })
+      callAll(afterFs, [])
     }
   }
 }
@@ -418,12 +434,26 @@ export const transact = (doc, f, origin = null, local = true) => {
     initialCall = true
     doc._transaction = new Transaction(doc, origin, local)
     transactionCleanups.push(doc._transaction)
-    if (transactionCleanups.length === 1) {
-      doc.emit('beforeAllTransactions', [doc])
-    }
-    doc.emit('beforeTransaction', [doc._transaction, doc])
   }
   try {
+    if (initialCall) {
+      const transaction = /** @type {Transaction} */ (doc._transaction)
+      /**
+       * Each callback is called even if the other ones throw errors.
+       *
+       * @type {Array<function():void>}
+       */
+      const beforeFs = []
+      if (transactionCleanups.length === 1) {
+        beforeFs.push(() => {
+          doc.emit('beforeAllTransactions', [doc])
+        })
+      }
+      beforeFs.push(() => {
+        doc.emit('beforeTransaction', [transaction, doc])
+      })
+      callAll(beforeFs, [])
+    }
     result = f(doc._transaction)
   } finally {
     if (initialCall) {

--- a/tests/doc.tests.js
+++ b/tests/doc.tests.js
@@ -313,6 +313,70 @@ export const testLoadDocsEvent = async _tc => {
 }
 
 /**
+ * A throwing document event handler must still finish transaction cleanup.
+ * The error still propagates, but later transactions must keep firing
+ * observers and update listeners.
+ *
+ * @see https://github.com/yjs/yjs/issues/799
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testThrowingDocEventHandlerDoesNotBreakLaterTransactions = _tc => {
+  /**
+   * @param {'update' | 'updateV2' | 'afterTransactionCleanup' | 'beforeTransaction' | 'beforeAllTransactions' | 'subdocs'} eventName
+   * @param {function(Y.Doc):void} trigger
+   */
+  const assertDocSurvivesThrowingHandler = (eventName, trigger) => {
+    const doc = new Y.Doc()
+    const yarray = doc.get('a')
+    const throwing = () => {
+      throw new Error('provider error')
+    }
+    let afterAllCount = 0
+    doc.on('afterAllTransactions', () => {
+      afterAllCount++
+    })
+    doc.on(eventName, throwing)
+    t.fails(() => {
+      trigger(doc)
+    })
+    t.assert(afterAllCount === 1, `${eventName}: transaction cleanup must finish`)
+    doc.off(eventName, throwing)
+
+    let observeCount = 0
+    yarray.observe(() => {
+      observeCount++
+    })
+    let updateCount = 0
+    doc.on('update', () => {
+      updateCount++
+    })
+    yarray.push([1])
+    t.assert(observeCount === 1, `${eventName}: observer must fire after throwing handler is removed`)
+    t.assert(updateCount === 1, `${eventName}: update must fire after throwing handler is removed`)
+  }
+
+  assertDocSurvivesThrowingHandler('update', doc => {
+    doc.get('a').push([0])
+  })
+  assertDocSurvivesThrowingHandler('updateV2', doc => {
+    doc.get('a').push([0])
+  })
+  assertDocSurvivesThrowingHandler('afterTransactionCleanup', doc => {
+    doc.get('a').push([0])
+  })
+  assertDocSurvivesThrowingHandler('beforeTransaction', doc => {
+    doc.get('a').push([0])
+  })
+  assertDocSurvivesThrowingHandler('beforeAllTransactions', doc => {
+    doc.get('a').push([0])
+  })
+  assertDocSurvivesThrowingHandler('subdocs', doc => {
+    doc.get('mysubdocs').setAttr('a', new Y.Doc({ guid: 'a' }))
+  })
+}
+
+/**
  * @param {t.TestCase} _tc
  */
 export const testSyncDocsEvent = async _tc => {


### PR DESCRIPTION
## Summary
A throwing `doc` event handler (`update`, `updateV2`, `afterTransactionCleanup`, `beforeTransaction`, `beforeAllTransactions`, `subdocs`) aborted transaction cleanup. `doc._transactionCleanups` stayed stale, so later observers and `update` listeners never ran.

Use the existing `callAll` pattern so cleanup continues (and still rethrows) when a handler throws.

Fixes #799

## Test plan
- [x] `NODE_ENV=development node ./tests/index.js --repetition-time 50 --filter "throwing doc"`